### PR TITLE
fix(dump,unix sockets): if 'name' is relative, real 'path' does not include that 'name', but 'realpath(name)' resolves to 'path', use 'cwd' as 'name_dir'

### DIFF
--- a/criu/sk-unix.c
+++ b/criu/sk-unix.c
@@ -696,12 +696,16 @@ static int unix_resolve_name(int lfd, uint32_t id, struct unix_sk_desc *d, UnixS
 	if (name[0] != '/') {
 		if (cut_path_ending(path, name)) {
 			pr_err("Unable too cut %s from %s\n", name, path);
-			goto out;
+			if (unix_resolve_name_old(lfd, id, d, ue, p)) {
+				pr_err("unix_resolve_name: unix_resolve_name_old failed\n");
+				goto out;
+			}
+            pr_debug("unix_resolve_name: unix_resolve_name_old fallback succeeded\n");
+		} else {
+            ue->name_dir = xstrdup(path);
+            if (!ue->name_dir)
+                goto out;
 		}
-
-		ue->name_dir = xstrdup(path);
-		if (!ue->name_dir)
-			goto out;
 
 		pr_debug("Resolved socket relative name %s to %s/%s\n", name, ue->name_dir, name);
 	}


### PR DESCRIPTION
I believe the original `unix_resolve_name` implementation around relative `name`s was targeting cases like:
```
name=var/run/secrets/workload-spiffe-uds/socket
path=/home/<...>/var/run/secrets/workload-spiffe-uds/socket
```
to yield `name_dir` as `/home/<...>`.

I also think the intent was to deal with changing socket paths:
> https://criu.org/Mount_points/2.0#Restore_of_unix_sockets
> For example, if you move a socket file, ss shows the origin address and you can’t find a file where the socket is bound. Another example is that an address may contain a relative path (../socket_name). 

---

```
    // "time=\"2025-11-07T17:46:45Z\" level=warning msg=\"
    // 1:Error (criu/sk-unix.c:698):
    //   unix: Unable too cut
    //    name=var/run/secrets/workload-spiffe-uds/socket
    //    path=/run/secrets/workload-spiffe-uds/socket
```
error example ^

`/var/run` is a `../run` symlink, i.e. `/run`.

It does not look like there's a way to build a pair of `name_dir` and `name` so that `${name_dir}/${name}` becomes equal to `${path}`.

---

I originally thought about checking whether `$name` exists in the current filesystem, but CRIU apparently runs in the root mount namespace by default:
```
msg="(criu/sk-unix.c:724): unix: getcwd succeeded: /var/tmp/work/3def9c39bef65c4fb9922ccb352cd590e0e7a8fc4f541162ae3bfa2a5a9f3fe0"
msg="(criu/sk-unix.c:728): unix: realpath failed for ./var/run/sockets/uds/echo.sock: No such file or directory"
```

`unix_resolve_name_old` appears to be doing the root/cwd resolution anyway, so why having a custom impl when existing one _does_ the trick.

I tested the solution with a:
```
apiVersion: v1
kind: Pod
metadata:
  name: uds-test-combined
  labels:
    app: uds-test-combined
spec:
  containers:
    - name: combined
      image: ...
      imagePullPolicy: Always
      env:
        - name: SOCKET_PATH
          value: "./var/run/sockets/uds/echo.sock"
        - name: SOCKET_TYPE
          value: "stream"
      volumeMounts:
        - name: uds-socket
          mountPath: /var/run/sockets/uds
  volumes:
    - name: uds-socket
      emptyDir: {}
  restartPolicy: Always
```
and `...`, which have a server and client communicating through a unix socket while being either same process or two different processes.

Cross-container communication (through a shared emptydir) volume would require using --ext-unix-sk https://criu.org/External_UNIX_socket, but I am not yet sure it is truly needed for istio case. I believe that volume mount was used in a single container.