### PR TITLE
feat: fix thread and fds not restoring properly

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -694,18 +694,18 @@ static int collect_remap_dead_process(struct reg_file_info *rfi, RemapFilePathEn
 
 	/*
 	 * First check if this PID/TID already exists in the dump.
-	 * If it's a thread (TASK_THREAD), we don't need a helper because
-	 * the thread will be restored normally and /proc/<pid>/task/<tid>
-	 * will exist.
+	 * Even if it's a thread (TASK_THREAD), we still need a helper because
+	 * threads are created later in the restorer (after FDs are opened),
+	 * so /proc/<pid>/task/<tid> won't exist yet when we try to open FDs.
+	 * The helper ensures the path exists during FD restoration.
 	 */
 	pid_node = pstree_pid_by_virt(rfe->remap_id);
 	if (pid_node) {
 		if (pid_node->state == TASK_THREAD) {
-			pr_info("Thread %d exists in dump, no helper needed for /proc/.../task/%d\n",
+			pr_info("Thread %d exists in dump, creating helper for /proc/.../task/%d\n",
 				rfe->remap_id, rfe->remap_id);
-			return 0;
-		}
-		if (pid_node->state != TASK_UNDEF) {
+			/* Fall through to create helper */
+		} else if (pid_node->state != TASK_UNDEF) {
 			pr_info("Skipping helper for restoring /proc/%d; pid exists\n", rfe->remap_id);
 			return 0;
 		}

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -694,18 +694,23 @@ static int collect_remap_dead_process(struct reg_file_info *rfi, RemapFilePathEn
 
 	/*
 	 * First check if this PID/TID already exists in the dump.
-	 * Even if it's a thread (TASK_THREAD), we still need a helper because
-	 * threads are created later in the restorer (after FDs are opened),
-	 * so /proc/<pid>/task/<tid> won't exist yet when we try to open FDs.
-	 * The helper ensures the path exists during FD restoration.
+	 * If it's a thread (TASK_THREAD), we DON'T create a helper because:
+	 * 1. Creating a helper with the TID would cause a TID collision when
+	 *    the real thread is created later
+	 * 2. The thread will be restored normally and /proc/<pid>/task/<tid>
+	 *    will eventually exist
+	 * 3. FD opening will retry until the thread is created (see open_path)
 	 */
 	pid_node = pstree_pid_by_virt(rfe->remap_id);
 	if (pid_node) {
 		if (pid_node->state == TASK_THREAD) {
-			pr_info("Thread %d exists in dump, creating helper for /proc/.../task/%d\n",
+			pr_info("Thread %d exists in dump, will retry FD opening for /proc/.../task/%d\n",
 				rfe->remap_id, rfe->remap_id);
-			/* Fall through to create helper */
-		} else if (pid_node->state != TASK_UNDEF) {
+			/* Don't create helper - would cause TID collision.
+			 * FD opening will check and retry (see do_open_reg_noseek_flags) */
+			return 0;
+		}
+		if (pid_node->state != TASK_UNDEF) {
 			pr_info("Skipping helper for restoring /proc/%d; pid exists\n", rfe->remap_id);
 			return 0;
 		}
@@ -2591,6 +2596,24 @@ int collect_filemap(struct vma_area *vma)
 static int open_fe_fd(struct file_desc *fd, int *new_fd)
 {
 	int tmp;
+	struct reg_file_info *rfi = container_of(fd, struct reg_file_info, d);
+
+	/*
+	 * For thread-specific /proc paths, check if the thread exists yet.
+	 * Threads are created in the restorer after FDs are opened, so we
+	 * need to retry until the thread is created.
+	 */
+	if (rfi->path && strstr(rfi->path, "/task/")) {
+		int mntns_root = mntns_get_root_by_mnt_id(rfi->rfe->mnt_id);
+		if (mntns_root < 0)
+			return -1;
+		if (faccessat(mntns_root, rfi->path, F_OK, 0) < 0) {
+			if (errno == ENOENT) {
+				pr_debug("Thread proc path %s doesn't exist yet, retrying\n", rfi->path);
+				return 1; /* Retry later */
+			}
+		}
+	}
 
 	tmp = open_path(fd, do_open_reg, NULL);
 	if (tmp < 0)

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1321,6 +1321,24 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms, 
 			return 0;
 		pid = strtol(start + 1, &end, 10);
 
+		/*
+		 * Check if this is a /proc/<pid>/task/<tid> path.
+		 * In this case, we need to create a helper for the thread (tid),
+		 * not the process (pid), since file descriptors may reference
+		 * thread-specific paths like /proc/1/task/156/stat.
+		 */
+		if (pid != 0 && end && strncmp(end, "/task/", 6) == 0) {
+			pid_t tid;
+			char *tid_end;
+
+			tid = strtol(end + 6, &tid_end, 10);
+			if (tid != 0) {
+				pr_debug("Detected /proc/%d/task/%d path\n", pid, tid);
+				pid = tid;
+				end = tid_end;
+			}
+		}
+
 		/* If strtol didn't convert anything, then we are looking at
 		 * something like /proc/kmsg, which we shouldn't mess with.
 		 * Anything under /proc/<pid> (including that directory itself)

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -690,6 +690,26 @@ static int open_remap_linked(struct reg_file_info *rfi)
 static int collect_remap_dead_process(struct reg_file_info *rfi, RemapFilePathEntry *rfe)
 {
 	struct pstree_item *helper;
+	struct pid *pid_node;
+
+	/*
+	 * First check if this PID/TID already exists in the dump.
+	 * If it's a thread (TASK_THREAD), we don't need a helper because
+	 * the thread will be restored normally and /proc/<pid>/task/<tid>
+	 * will exist.
+	 */
+	pid_node = pstree_pid_by_virt(rfe->remap_id);
+	if (pid_node) {
+		if (pid_node->state == TASK_THREAD) {
+			pr_info("Thread %d exists in dump, no helper needed for /proc/.../task/%d\n",
+				rfe->remap_id, rfe->remap_id);
+			return 0;
+		}
+		if (pid_node->state != TASK_UNDEF) {
+			pr_info("Skipping helper for restoring /proc/%d; pid exists\n", rfe->remap_id);
+			return 0;
+		}
+	}
 
 	helper = lookup_create_item(rfe->remap_id);
 	if (!helper)


### PR DESCRIPTION
# Vibe coder says this:
  ## Root Cause

  The bug is in criu/files-reg.c around lines 1306-1356, in the logic that
  handles file descriptors pointing to /proc paths.

  ## The Problem

  When CRIU dumps a file descriptor that references a path like:
  /proc/1/task/156/stat

  The current code at files-reg.c:1322 does:
  pid = strtol(start + 1, &end, 10);

  This extracts PID = 1 (the main process ID) instead of TID = 156 (the
  thread ID).

  The code then calls dump_dead_process_remap(pid=1, id), which tells CRIU
  to create a helper task for PID 1 during restore.

  ## Why This Causes Failures

  During restore:
  1. CRIU tries to open file descriptors that reference
  /proc/1/task/156/stat
  2. But thread 156 doesn't exist yet because it was recorded as needing PID
   1, not TID 156
  3. The openat() call at files-reg.c:2351 fails with "No such file or
  directory"
  4. This causes the errors you're seeing:
  Can't open file proc/1/task/156/stat on restore: No such file or directory
  Unable to open fd=895 id=0x3a2

  ## The Fix

  The code needs to detect paths containing /task/<tid> and extract the
  thread ID instead of the process ID. Here's the specific location that
  needs modification:

  Location: criu/files-reg.c:1314-1353

  ## The fix should:
  1. After extracting the initial PID, check if the path continues with
  /task/
  2. If yes, extract the TID after /task/ instead
  3. Use the TID for dump_dead_process_remap()
