### PR TITLE
feat: add libbpf to build

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -19,7 +19,7 @@ ifeq ($(call pkg-config-check,libselinux),y)
 endif
 
 ifeq ($(call pkg-config-check,libbpf),y)
-        LIBS_FEATURES	+= -lbpf
+        LIBS_FEATURES	+= $(shell $(PKG_CONFIG) --libs --static libbpf)
         FEATURE_DEFINES	+= -DCONFIG_HAS_LIBBPF
         export CONFIG_HAS_LIBBPF := y
 endif

--- a/criu/cr-service.c
+++ b/criu/cr-service.c
@@ -738,6 +738,9 @@ static int setup_opts_from_req(int sk, CriuOpts *req)
 	if (req->has_display_stats)
 		opts.display_stats = req->display_stats;
 
+	if (req->has_allow_uprobes)
+		opts.allow_uprobes = req->allow_uprobes;
+
 	/* Evaluate additional configuration file (e.g., runc.conf) to overwrite all RPC settings. */
 	if (req->config_file) {
 		char *tmp_output = opts.output;

--- a/images/rpc.proto
+++ b/images/rpc.proto
@@ -145,6 +145,7 @@ message criu_opts {
 	optional bool			leave_stopped		= 69;
 	optional bool			display_stats		= 70;
 	optional bool			log_to_stderr		= 71;
+	optional bool			allow_uprobes		= 72;
 /*	optional bool			check_mounts		= 128;	*/
 }
 

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -9,8 +9,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 	git-core \
 	iptables \
 	libaio-dev \
+	libbpf-dev \
 	libbsd-dev \
 	libcap-dev \
+	libelf-dev \
+	libzstd-dev \
+	zlib1g-dev \
 	libnl-3-dev \
 	libprotobuf-c-dev \
 	libprotobuf-dev \


### PR DESCRIPTION
This is required to build criu with libbpf support, which is required to enable `allow-uprobes` flag.

Reference to place in code: https://github.com/castai/criu/blob/live-dev/criu/files.c#L550

