### PR TITLE
fix: restore AIO on systems with larger min size

### DIFF
--- a/criu/aio.c
+++ b/criu/aio.c
@@ -1,6 +1,5 @@
 #include <unistd.h>
 #include <stdio.h>
-#include <stdbool.h>
 #include "vma.h"
 #include "xmalloc.h"
 #include "pstree.h"
@@ -12,6 +11,10 @@
 #include "parasite-syscall.h"
 #include "images/mm.pb-c.h"
 #include "compel/infect.h"
+#include "linux/aio_abi.h"
+
+/* AIO preparation with expansion support for live migration */
+#include "live_prepare_aio.c"
 
 #define NR_IOEVENTS_IN_NPAGES(npages) ((PAGE_SIZE * (npages) - sizeof(struct aio_ring)) / sizeof(struct io_event))
 
@@ -125,7 +128,9 @@ int parasite_collect_aios(struct parasite_ctl *ctl, struct vm_area_list *vmas)
 int prepare_aios(struct pstree_item *t, struct task_restore_args *ta)
 {
 	int i;
-	MmEntry *mm = rsti(t)->mm;
+	struct rst_info *ri = rsti(t);
+	MmEntry *mm = ri->mm;
+
 	/*
 	 * Put info about AIO rings, they will get remapped
 	 */
@@ -143,6 +148,9 @@ int prepare_aios(struct pstree_item *t, struct task_restore_args *ta)
 		raio->addr = mm->aios[i]->id;
 		raio->nr_req = mm->aios[i]->nr_req;
 		raio->len = mm->aios[i]->ring_len;
+
+		if (live_prepare_aio_ring(raio, mm->aios[i], &ri->vmas))
+			return -1;
 	}
 
 	return 0;

--- a/criu/include/aio.h
+++ b/criu/include/aio.h
@@ -28,8 +28,10 @@ struct aio_ring {
 };
 
 struct rst_aio_ring {
-	unsigned long addr;
-	unsigned long len;
-	unsigned int nr_req;
+	unsigned long addr;	/* Original address from dump */
+	unsigned long len;	/* Original ring length */
+	unsigned int nr_req;	/* Number of requests (for io_setup) */
+	unsigned long max_len;	/* Max available space at addr (for expansion check) */
+	unsigned long new_addr;	/* Set by restorer if relocation needed, 0 otherwise */
 };
 #endif /* __CR_AIO_H__ */

--- a/criu/live_prepare_aio.c
+++ b/criu/live_prepare_aio.c
@@ -1,0 +1,84 @@
+/*
+ * AIO ring preparation with expansion support for live migration.
+ *
+ * When restoring on a system with more CPUs, the kernel may create larger
+ * AIO rings. This file calculates how much space is available at each
+ * ring's original address, allowing the restorer to expand in place when
+ * possible (avoiding the need to relocate and patch memory references).
+ *
+ * This file is included directly into aio.c.
+ */
+
+/*
+ * Calculate the maximum length available at an AIO ring's address.
+ *
+ * Looks at the VMA list to find how much contiguous free space exists
+ * starting from the ring's address. This allows the restorer to know
+ * if it can expand the ring in place or needs to relocate it.
+ *
+ * Returns the maximum length available (at least raio->len, potentially more).
+ */
+static unsigned long live_calc_aio_max_len(struct rst_aio_ring *raio,
+					   struct vm_area_list *vmas)
+{
+	struct vma_area *vma;
+	unsigned long ring_end = raio->addr + raio->len;
+	unsigned long max_end;
+
+	/*
+	 * Start with a reasonable upper bound. We don't want to claim
+	 * unlimited space even if nothing follows.
+	 */
+	max_end = raio->addr + (16 * 1024 * 1024); /* 16MB max */
+
+	/*
+	 * Find the first VMA that starts after our ring.
+	 * The space between ring_end and that VMA's start is available.
+	 */
+	list_for_each_entry(vma, &vmas->h, list) {
+		/* Skip VMAs that end before or at our ring's end */
+		if (vma->e->end <= ring_end)
+			continue;
+
+		/* Skip the AIO ring VMA itself */
+		if (vma->e->start == raio->addr)
+			continue;
+
+		/*
+		 * This VMA starts after our ring. The available space
+		 * is from ring start to this VMA's start.
+		 */
+		if (vma->e->start > raio->addr) {
+			max_end = vma->e->start;
+			break;
+		}
+	}
+
+	return max_end - raio->addr;
+}
+
+/*
+ * Prepare AIO ring info with expansion limits.
+ *
+ * For each AIO ring, calculate how much space is available at its
+ * original address. This information is passed to the restorer which
+ * uses it to decide whether to expand in place or relocate.
+ */
+static int live_prepare_aio_ring(struct rst_aio_ring *raio,
+				 AioRingEntry *aio_entry,
+				 struct vm_area_list *vmas)
+{
+	raio->new_addr = 0;
+
+	/*
+	 * Calculate how much space is available at the original address.
+	 * This allows the restorer to expand the ring in place if the
+	 * kernel creates a larger ring (due to more CPUs).
+	 */
+	raio->max_len = live_calc_aio_max_len(raio, vmas);
+
+	pr_debug("AIO ring at 0x%lx: len=%lu, max_len=%lu\n",
+		 raio->addr, raio->len, raio->max_len);
+
+	return 0;
+}

--- a/criu/pie/live_restore_aio.c
+++ b/criu/pie/live_restore_aio.c
@@ -1,0 +1,143 @@
+/*
+ * AIO ring helpers for live migration.
+ *
+ * When restoring on a system with more CPUs, the kernel may create larger
+ * AIO rings. If the ring can't expand in place, we relocate it and patch
+ * all memory references.
+ *
+ * This file is included directly into restorer.c to keep it in the same
+ * translation unit (required for PIE code).
+ */
+
+/*
+ * Calculate the page-aligned size of an AIO ring.
+ */
+static inline unsigned long live_aio_ring_size(unsigned int nr)
+{
+	unsigned long size = sizeof(struct aio_ring) + nr * sizeof(struct io_event);
+	return (size + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
+}
+
+/*
+ * Handle AIO ring expansion for live migration.
+ *
+ * When restoring on a system with more CPUs, the kernel creates larger rings.
+ * This function decides whether to expand in place or relocate, and prepares
+ * the address space accordingly.
+ *
+ * Returns: new ring length on success, 0 on failure
+ */
+static unsigned long live_handle_aio_expansion(struct rst_aio_ring *raio,
+					       struct aio_ring *new,
+					       unsigned long ctx)
+{
+	unsigned long new_ring_len = live_aio_ring_size(new->nr);
+
+	if (new_ring_len > raio->max_len) {
+		/*
+		 * Cannot expand in place - will relocate ring to new location.
+		 * The ring stays at ctx (where io_setup placed it).
+		 */
+		pr_info("AIO ring relocation: 0x%lx -> 0x%lx (no space)\n",
+			raio->addr, ctx);
+		raio->new_addr = ctx;
+	} else if (new_ring_len > raio->len) {
+		/*
+		 * Expand in place: unmap extra area after original ring
+		 * to make room for the larger ring.
+		 */
+		unsigned long extra = new_ring_len - raio->len;
+		void *extra_addr = (void *)(raio->addr + raio->len);
+		int ret;
+
+		ret = sys_munmap(extra_addr, extra);
+		if (ret < 0 && ret != -EINVAL) {
+			pr_err("Cannot free space for AIO ring at %lx: %d\n",
+			       raio->addr, ret);
+			return 0;
+		}
+	}
+
+	return new_ring_len;
+}
+
+/*
+ * Finalize AIO ring placement.
+ *
+ * For non-relocated rings, moves the ring to its original address.
+ * For relocated rings, the ring stays at the kernel-chosen location.
+ *
+ * Returns: 0 on success, -1 on failure
+ */
+static int live_finalize_aio_ring(struct rst_aio_ring *raio,
+				  unsigned long ctx,
+				  unsigned long ring_len)
+{
+	if (!raio->new_addr) {
+		ctx = sys_mremap(ctx, ring_len, ring_len,
+				 MREMAP_FIXED | MREMAP_MAYMOVE, raio->addr);
+		if (ctx != raio->addr) {
+			pr_err("Ring remap failed with %ld\n", ctx);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+/*
+ * Patch memory to update aio_context_t references after AIO ring relocation.
+ * Scans writable VMAs for the old address and replaces with the new address.
+ *
+ * This is necessary because applications store the aio_context_t (ring address)
+ * and use it for io_submit/io_getevents calls. If we relocate the ring, we need
+ * to update these stored references.
+ */
+static int live_patch_aio_context_refs(struct task_restore_args *args,
+				       unsigned long old_addr,
+				       unsigned long new_addr)
+{
+	int i;
+	int patched = 0;
+
+	pr_info("Patching aio_context_t: 0x%lx -> 0x%lx\n", old_addr, new_addr);
+
+	for (i = 0; i < args->vmas_n; i++) {
+		VmaEntry *vma = &args->vmas[i];
+		unsigned long addr;
+		unsigned long *ptr;
+
+		if (!(vma->prot & PROT_WRITE))
+			continue;
+
+		if (vma->status & VMA_AREA_AIORING)
+			continue;
+
+		if ((vma->status & VMA_AREA_VDSO) ||
+		    (vma->status & VMA_AREA_VVAR) ||
+		    (vma->status & VMA_AREA_VSYSCALL))
+			continue;
+
+		/*
+		 * Scan this VMA for the old address value.
+		 * Only check aligned positions (aio_context_t is unsigned long).
+		 */
+		for (addr = vma->start; addr + sizeof(unsigned long) <= vma->end;
+		     addr += sizeof(unsigned long)) {
+			ptr = (unsigned long *)addr;
+			if (*ptr == old_addr) {
+				pr_info("Patched aio_context_t at 0x%lx\n", addr);
+				*ptr = new_addr;
+				patched++;
+			}
+		}
+	}
+
+	if (patched == 0) {
+		pr_warn("No aio_context_t references found to patch (old=0x%lx)\n",
+			old_addr);
+	} else {
+		pr_info("Patched %d aio_context_t reference(s)\n", patched);
+	}
+
+	return 0;
+}

--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -51,6 +51,9 @@
 
 #include "shmem.h"
 
+/* AIO restoration with relocation support for live migration */
+#include "live_restore_aio.c"
+
 /*
  * sys_getgroups() buffer size. Not too much, to avoid stack overflow.
  */
@@ -936,6 +939,7 @@ static int restore_aio_ring(struct rst_aio_ring *raio)
 	unsigned tail = ring->tail;
 	struct iocb *iocb, **iocbp;
 	unsigned long ctx = 0;
+	unsigned long ring_len;
 	unsigned size;
 	char buf[1];
 
@@ -947,11 +951,21 @@ static int restore_aio_ring(struct rst_aio_ring *raio)
 
 	new = (struct aio_ring *)ctx;
 	i = (raio->len - sizeof(struct aio_ring)) / sizeof(struct io_event);
-	if (tail >= ring->nr || head >= ring->nr || ring->nr != i || new->nr != ring->nr) {
+	if (tail >= ring->nr || head >= ring->nr || ring->nr != i || new->nr < ring->nr) {
 		pr_err("wrong aio: tail=%x head=%x req=%x old_nr=%x new_nr=%x expect=%x\n", tail, head, raio->nr_req,
 		       ring->nr, new->nr, i);
 
 		return -1;
+	}
+
+	ring_len = raio->len;
+
+	/* Handle ring expansion for live migration (more CPUs on restore) */
+	if (new->nr > ring->nr) {
+		pr_info("AIO ring expanded: old_nr=%x new_nr=%x\n", ring->nr, new->nr);
+		ring_len = live_handle_aio_expansion(raio, new, ctx);
+		if (!ring_len)
+			return -1;
 	}
 
 	if (tail == 0 && head == 0)
@@ -1028,24 +1042,7 @@ populate:
 	i = offsetof(struct aio_ring, io_events);
 	memcpy((void *)ctx + i, (void *)ring + i, raio->len - i);
 
-	/*
-	 * If we failed to get the proper nr_req right and
-	 * created smaller or larger ring, then this remap
-	 * will (should) fail, since AIO rings has immutable
-	 * size.
-	 *
-	 * This is not great, but anyway better than putting
-	 * a ring of wrong size into correct place.
-	 *
-	 * Also, this unmaps temporary anonymous area on raio->addr.
-	 */
-
-	ctx = sys_mremap(ctx, raio->len, raio->len, MREMAP_FIXED | MREMAP_MAYMOVE, raio->addr);
-	if (ctx != raio->addr) {
-		pr_err("Ring remap failed with %ld\n", ctx);
-		return -1;
-	}
-	return 0;
+	return live_finalize_aio_ring(raio, ctx, ring_len);
 }
 
 static void rst_tcp_repair_off(struct rst_tcp_sock *rts)
@@ -1969,13 +1966,20 @@ __visible long __export_restore_task(struct task_restore_args *args)
 	}
 
 	/*
-	 * Now when all VMAs are in their places time to set
-	 * up AIO rings.
+	 * Now when all VMAs are in their places time to set up AIO rings.
 	 */
+	for (i = 0; i < args->rings_n; i++) {
+		struct rst_aio_ring *raio = &args->rings[i];
 
-	for (i = 0; i < args->rings_n; i++)
-		if (restore_aio_ring(&args->rings[i]) < 0)
+		if (restore_aio_ring(raio) < 0)
 			goto core_restore_end;
+
+		/* If ring was relocated, patch memory references */
+		if (raio->new_addr) {
+			if (live_patch_aio_context_refs(args, raio->addr, raio->new_addr) < 0)
+				goto core_restore_end;
+		}
+	}
 
 	/*
 	 * Finally restore madivse() bits


### PR DESCRIPTION
The AIO size has a minimum based on amount of CPUs available. If the
size that we dumped is smaller than the minimum on the destination we
need to create a ring in a new location and fix the references to it in
the VMAs.
This patch of the references isn't ideal, but as this causes the
restoration to fail, it is best effort.