### PR TITLE
fix: repair sockets when --keep-network-lock enabled

### DIFF
--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -2095,14 +2095,7 @@ static int cr_dump_finish(int ret)
 	 */
 	if (ret || post_dump_ret || opts.final_state == TASK_ALIVE) {
 		unsuspend_lsm();
-		/*
-		 * For live migration we want to be able to recover the process(es) in case
-		 * the restoration fails. When --keep-network-lock is specified, the network
-		 * lock is kept until we actually need to recover.
-		 */
-		if (!opts.keep_network_lock) {
-			network_unlock();
-		}
+		network_unlock();
 		delete_link_remaps();
 		clean_cr_time_mounts();
 	}

--- a/criu/net.c
+++ b/criu/net.c
@@ -3487,6 +3487,11 @@ void network_unlock(void)
 	cpt_unlock_tcp_connections();
 	rst_unlock_tcp_connections();
 
+	if (opts.keep_network_lock) {
+		pr_info("Keeping network lock\n");
+		return;
+	}
+
 	if (root_ns_mask & CLONE_NEWNET) {
 		/* coverity[check_return] */
 		run_scripts(ACT_NET_UNLOCK);


### PR DESCRIPTION
Sockets have to still be repaired otherwise they can't be used by the process.