### PR TITLE
feat(tcp): restore socket with UID

### DIFF
--- a/criu/include/sk-inet.h
+++ b/criu/include/sk-inet.h
@@ -41,7 +41,9 @@ struct inet_sk_desc {
 	unsigned int dst_addr[4];
 	unsigned short shutdown;
 	bool cork;
+    // == CastAI Live patches ==
 	unsigned int uid;
+    // == CastAI Live patches ==
 
 	int rfd;
 	int cpt_reuseaddr;

--- a/criu/include/sk-inet.h
+++ b/criu/include/sk-inet.h
@@ -41,6 +41,7 @@ struct inet_sk_desc {
 	unsigned int dst_addr[4];
 	unsigned short shutdown;
 	bool cork;
+	unsigned int uid;
 
 	int rfd;
 	int cpt_reuseaddr;

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -906,10 +906,10 @@ static int open_inet_sk(struct file_desc *d, int *new_fd)
 		old_fsuid = setfsuid(ie->uid);
 		if ((uid_t)setfsuid(-1) != ie->uid)
 			pr_warn("Couldn't set fsuid to %u for inet socket; "
-				"sk_uid will be %d. xt_owner rules may misbehave.\n",
+				"sk_uid will be %u. xt_owner rules may misbehave.\n",
 				ie->uid, old_fsuid);
 		else
-			pr_debug("Creating inet socket with fsuid %u (was %d)\n",
+			pr_debug("Creating inet socket with fsuid %u (was %u)\n",
 				 ie->uid, old_fsuid);
 		restore_fsuid = true;
 	}

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -17,6 +17,8 @@
 #include <linux/in.h>
 #include <linux/in6.h>
 
+#include <sys/fsuid.h>
+
 #include "../soccr/soccr.h"
 
 #include "libnetlink.h"
@@ -271,6 +273,7 @@ static struct inet_sk_desc *gen_uncon_sk(int lfd, const struct fd_parms *p, int 
 
 	sk->sd.family = family;
 	sk->type = type;
+	sk->uid = p->stat.st_uid;
 
 	if (sk->sd.family == AF_INET)
 		aux = sizeof(struct sockaddr_in);
@@ -526,6 +529,8 @@ static int do_dump_one_inet_fd(int lfd, u32 id, const struct fd_parms *p, int fa
 	ie.dst_port = sk->dst_port;
 	ie.backlog = sk->wqlen;
 	ie.flags = p->flags;
+	ie.uid = sk->uid;
+	ie.has_uid = true;
 
 	ie.fown = (FownEntry *)&p->fown;
 	ie.opts = &skopts;
@@ -676,6 +681,7 @@ int inet_collect_one(struct nlmsghdr *h, int family, int type, struct ns_id *ns)
 	d->state = m->idiag_state;
 	d->rqlen = m->idiag_rqueue;
 	d->wqlen = m->idiag_wqueue;
+	d->uid = m->idiag_uid;
 	memcpy(d->src_addr, m->id.idiag_src, sizeof(u32) * 4);
 	memcpy(d->dst_addr, m->id.idiag_dst, sizeof(u32) * 4);
 
@@ -856,6 +862,8 @@ static int open_inet_sk(struct file_desc *d, int *new_fd)
 	struct inet_sk_info *ii;
 	InetSkEntry *ie;
 	int sk, yes = 1;
+	uid_t old_fsuid = 0;
+	bool restore_fsuid = false;
 
 	if (fle->stage >= FLE_OPEN)
 		return post_open_inet_sk(d, fle->fe->fd);
@@ -884,7 +892,33 @@ static int open_inet_sk(struct file_desc *d, int *new_fd)
 	if (run_setsockcreatecon(fle->fe))
 		return -1;
 
+	/*
+	 * The kernel stamps sk->sk_uid from current_fsuid() at socket creation and exposes no interface to change it later.
+	 * To preserve the dumped uid (so xt_owner --uid-owner rules keep working after restore), switch fsuid around socket(2).
+	 * setfsuid needs only ns-level CAP_SETUID, which we already have.
+	 *
+	 * Caveat: ie->uid is the uid as seen from the userns in which CRIU dumped inet_diag.
+	 * For non-userns containers (the common k8s case) that equals the container-local uid and everything lines up.
+	 * For userns containers where CRIU dumps from the host ns, ie->uid is an unmapped host uid inside the container's
+	 * userns and setfsuid will silently not take effect — we log a warning below so the symptom is visible.
+	 */
+	if (ie->has_uid) {
+		old_fsuid = setfsuid(ie->uid);
+		if ((uid_t)setfsuid(-1) != ie->uid)
+			pr_warn("Couldn't set fsuid to %u for inet socket; "
+				"sk_uid will be %d. xt_owner rules may misbehave.\n",
+				ie->uid, old_fsuid);
+		else
+			pr_debug("Creating inet socket with fsuid %u (was %d)\n",
+				 ie->uid, old_fsuid);
+		restore_fsuid = true;
+	}
+
 	sk = socket(ie->family, ie->type, ie->proto);
+
+	if (restore_fsuid)
+		setfsuid(old_fsuid);
+
 	if (sk < 0) {
 		pr_perror("Can't create inet socket");
 		return -1;

--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -17,7 +17,9 @@
 #include <linux/in.h>
 #include <linux/in6.h>
 
+// == CastAI Live patches ==
 #include <sys/fsuid.h>
+// == CastAI Live patches ==
 
 #include "../soccr/soccr.h"
 
@@ -273,7 +275,9 @@ static struct inet_sk_desc *gen_uncon_sk(int lfd, const struct fd_parms *p, int 
 
 	sk->sd.family = family;
 	sk->type = type;
+    // == CastAI Live patches ==
 	sk->uid = p->stat.st_uid;
+    // == CastAI Live patches ==
 
 	if (sk->sd.family == AF_INET)
 		aux = sizeof(struct sockaddr_in);
@@ -529,8 +533,10 @@ static int do_dump_one_inet_fd(int lfd, u32 id, const struct fd_parms *p, int fa
 	ie.dst_port = sk->dst_port;
 	ie.backlog = sk->wqlen;
 	ie.flags = p->flags;
+    // == CastAI Live patches ==
 	ie.uid = sk->uid;
 	ie.has_uid = true;
+    // == CastAI Live patches ==
 
 	ie.fown = (FownEntry *)&p->fown;
 	ie.opts = &skopts;
@@ -862,8 +868,10 @@ static int open_inet_sk(struct file_desc *d, int *new_fd)
 	struct inet_sk_info *ii;
 	InetSkEntry *ie;
 	int sk, yes = 1;
+    // == CastAI Live patches ==
 	uid_t old_fsuid = 0;
 	bool restore_fsuid = false;
+    // == CastAI Live patches ==
 
 	if (fle->stage >= FLE_OPEN)
 		return post_open_inet_sk(d, fle->fe->fd);
@@ -892,6 +900,7 @@ static int open_inet_sk(struct file_desc *d, int *new_fd)
 	if (run_setsockcreatecon(fle->fe))
 		return -1;
 
+    // == CastAI Live patches ==
 	/*
 	 * The kernel stamps sk->sk_uid from current_fsuid() at socket creation and exposes no interface to change it later.
 	 * To preserve the dumped uid (so xt_owner --uid-owner rules keep working after restore), switch fsuid around socket(2).
@@ -913,11 +922,14 @@ static int open_inet_sk(struct file_desc *d, int *new_fd)
 				 ie->uid, old_fsuid);
 		restore_fsuid = true;
 	}
+    // == CastAI Live patches ==
 
 	sk = socket(ie->family, ie->type, ie->proto);
 
+    // == CastAI Live patches ==
 	if (restore_fsuid)
 		setfsuid(old_fsuid);
+    // == CastAI Live patches ==
 
 	if (sk < 0) {
 		pr_perror("Can't create inet socket");

--- a/images/sk-inet.proto
+++ b/images/sk-inet.proto
@@ -59,10 +59,12 @@ message inet_sk_entry {
 	optional sk_shutdown		shutdown	= 19;
 	optional tcp_opts_entry		tcp_opts	= 20;
 
+  // == CastAI Live patches ==
 	/*
 	 * The fsuid that owned the socket at dump time (from inet_diag idiag_uid).
 	 * Restored via setfsuid() around socket(2) so
 	 * the kernel stamps sk->sk_uid correctly — xt_owner --uid-owner matches on it.
 	 */
 	optional uint32			uid		= 21;
+  // == CastAI Live patches ==
 }

--- a/images/sk-inet.proto
+++ b/images/sk-inet.proto
@@ -58,4 +58,11 @@ message inet_sk_entry {
 	optional uint32			ns_id		= 18;
 	optional sk_shutdown		shutdown	= 19;
 	optional tcp_opts_entry		tcp_opts	= 20;
+
+	/*
+	 * The fsuid that owned the socket at dump time (from inet_diag idiag_uid).
+	 * Restored via setfsuid() around socket(2) so
+	 * the kernel stamps sk->sk_uid correctly — xt_owner --uid-owner matches on it.
+	 */
+	optional uint32			uid		= 21;
 }

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -129,6 +129,7 @@ TST_NOFILE	:=				\
 		socket-tcp-close2		\
 		socket-dump-tcp-close 		\
 		socket-tcp-localhost		\
+		socket-tcp-uid			\
 		socket-tcp-unconn		\
 		socket-tcp6-unconn		\
 		socket-tcp-syn-sent		\

--- a/test/zdtm/static/socket-tcp-uid.c
+++ b/test/zdtm/static/socket-tcp-uid.c
@@ -141,10 +141,10 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	/* Pre-dump: confirm the kernel agrees the stamp took, so a
+	/* before dump: confirm the kernel agrees the stamp took, so a
 	 * failure after C/R is unambiguously a restore-side regression. */
 	if (fstat(fd, &st)) {
-		pr_perror("fstat pre-dump");
+		pr_perror("fstat failed BEFORE dump");
 		return 1;
 	}
 	got = sk_uid_for_inode(st.st_ino);

--- a/test/zdtm/static/socket-tcp-uid.c
+++ b/test/zdtm/static/socket-tcp-uid.c
@@ -19,32 +19,6 @@ const char *test_author = "Dmytro Bainak <dmytro.bainak@cast.ai>";
 
 static int port = 8880;
 
-static int read_data(int fd, unsigned char *buf, int size)
-{
-	int cur = 0, ret;
-
-	while (cur != size) {
-		ret = read(fd, buf + cur, size - cur);
-		if (ret <= 0)
-			return -1;
-		cur += ret;
-	}
-	return 0;
-}
-
-static int write_data(int fd, const unsigned char *buf, int size)
-{
-	int cur = 0, ret;
-
-	while (cur != size) {
-		ret = write(fd, buf + cur, size - cur);
-		if (ret <= 0)
-			return -1;
-		cur += ret;
-	}
-	return 0;
-}
-
 /*
  * Look up the uid column in /proc/net/tcp for the row whose inode
  * matches `ino`. Inode is unique across sockets, so this avoids

--- a/test/zdtm/static/socket-tcp-uid.c
+++ b/test/zdtm/static/socket-tcp-uid.c
@@ -1,0 +1,215 @@
+#include "zdtmtst.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/fsuid.h>
+#include <netinet/tcp.h>
+
+const char *test_doc = "Check that sk_uid is preserved on inet socket C/R\n";
+const char *test_author = "Dmytro Bainak <dmytro.bainak@cast.ai>";
+
+#define TEST_UID	1337
+#define BUF_SIZE	4096
+
+static int port = 8880;
+
+static int read_data(int fd, unsigned char *buf, int size)
+{
+	int cur = 0, ret;
+
+	while (cur != size) {
+		ret = read(fd, buf + cur, size - cur);
+		if (ret <= 0)
+			return -1;
+		cur += ret;
+	}
+	return 0;
+}
+
+static int write_data(int fd, const unsigned char *buf, int size)
+{
+	int cur = 0, ret;
+
+	while (cur != size) {
+		ret = write(fd, buf + cur, size - cur);
+		if (ret <= 0)
+			return -1;
+		cur += ret;
+	}
+	return 0;
+}
+
+/*
+ * Look up the uid column in /proc/net/tcp for the row whose inode
+ * matches `ino`. Inode is unique across sockets, so this avoids
+ * confusing the LISTEN sk with the ESTABLISHED accepted sk that
+ * share the same local port.
+ */
+static uid_t sk_uid_for_inode(unsigned long ino)
+{
+	FILE *f;
+	char line[512];
+	uid_t found = (uid_t)-1;
+
+	f = fopen("/proc/net/tcp", "r");
+	if (!f) {
+		pr_perror("open /proc/net/tcp");
+		return (uid_t)-1;
+	}
+
+	if (!fgets(line, sizeof(line), f))
+		goto out;
+
+	while (fgets(line, sizeof(line), f)) {
+		unsigned int uid;
+		unsigned long inode;
+		/*
+		 * sl  local rem  st  tx:rx  tr:when  retr  uid  to  inode
+		 *  *   *    *    *    *      *        *    %u   *   %lu
+		 */
+		if (sscanf(line, " %*s %*s %*s %*s %*s %*s %*s %u %*s %lu",
+			   &uid, &inode) != 2)
+			continue;
+		if (inode == ino) {
+			found = (uid_t)uid;
+			break;
+		}
+	}
+out:
+	fclose(f);
+	return found;
+}
+
+int main(int argc, char **argv)
+{
+	unsigned char buf[BUF_SIZE];
+	int fd, fd_s, fd_c;
+	pid_t cpid;
+	uint32_t crc;
+	int pfd[2];
+	struct stat st;
+	uid_t got;
+
+	test_init(argc, argv);
+
+	if (pipe(pfd)) {
+		pr_perror("pipe");
+		return 1;
+	}
+
+	cpid = fork();
+	if (cpid < 0) {
+		pr_perror("fork");
+		return 1;
+	}
+
+	if (cpid == 0) {
+		/* Child: plain TCP client. Its only job is to keep the
+		 * connection peer alive across C/R and echo one buffer. */
+		close(pfd[1]);
+		if (read(pfd[0], &port, sizeof(port)) != sizeof(port)) {
+			pr_perror("read port");
+			return 1;
+		}
+		close(pfd[0]);
+
+		fd_c = tcp_init_client(AF_INET, "localhost", port);
+		if (fd_c < 0)
+			return 1;
+
+		if (read_data(fd_c, buf, BUF_SIZE)) {
+			pr_perror("client read");
+			return 1;
+		}
+		if (datachk(buf, BUF_SIZE, &crc))
+			return 2;
+		datagen(buf, BUF_SIZE, &crc);
+		if (write_data(fd_c, buf, BUF_SIZE)) {
+			pr_perror("client write");
+			return 1;
+		}
+		return 0;
+	}
+
+	if ((fd_s = tcp_init_server(AF_INET, &port)) < 0) {
+		pr_err("server init failed\n");
+		return 1;
+	}
+
+	close(pfd[0]);
+	if (write(pfd[1], &port, sizeof(port)) != sizeof(port)) {
+		pr_perror("send port");
+		return 1;
+	}
+	close(pfd[1]);
+
+	/*
+	 * The kernel reads current_fsuid() in sock_init_data() at socket
+	 * birth, which for an accepted socket is inside accept(). Switch
+	 * fsuid around accept() so the new sk gets sk_uid = TEST_UID
+	 * while euid stays root (required for CRIU to checkpoint TCP).
+	 */
+	setfsuid(TEST_UID);
+	if ((uid_t)setfsuid(-1) != TEST_UID) {
+		pr_err("setfsuid(TEST_UID) did not take effect\n");
+		return 1;
+	}
+	fd = tcp_accept_server(fd_s);
+	setfsuid(0);
+	if (fd < 0) {
+		pr_err("accept failed\n");
+		return 1;
+	}
+
+	/* Pre-dump: confirm the kernel agrees the stamp took, so a
+	 * failure after C/R is unambiguously a restore-side regression. */
+	if (fstat(fd, &st)) {
+		pr_perror("fstat pre-dump");
+		return 1;
+	}
+	got = sk_uid_for_inode(st.st_ino);
+	if (got != TEST_UID) {
+		fail("pre-dump: sk_uid is %u, want %u (inode %lu)",
+		     got, TEST_UID, st.st_ino);
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	/* Restored socket gets a fresh kernel inode; re-fstat to find it. */
+	if (fstat(fd, &st)) {
+		pr_perror("fstat post-restore");
+		return 1;
+	}
+	got = sk_uid_for_inode(st.st_ino);
+	if (got != TEST_UID) {
+		fail("post-restore: sk_uid is %u, want %u (inode %lu)",
+		     got, TEST_UID, st.st_ino);
+		return 1;
+	}
+
+	/* Light connection-integrity check, same shape as socket-tcp-local. */
+	datagen(buf, BUF_SIZE, &crc);
+	if (write_data(fd, buf, BUF_SIZE)) {
+		pr_perror("parent write after restore");
+		return 1;
+	}
+	if (read_data(fd, buf, BUF_SIZE)) {
+		pr_perror("parent read after restore");
+		return 1;
+	}
+	if (datachk(buf, BUF_SIZE, &crc)) {
+		fail("data integrity check failed");
+		return 2;
+	}
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/socket-tcp-uid.desc
+++ b/test/zdtm/static/socket-tcp-uid.desc
@@ -1,0 +1,1 @@
+{'flavor': 'h ns', 'opts': '--tcp-established', 'flags': 'suid nouser samens'}


### PR DESCRIPTION
Istio has a bunch of iptables rules that match connections that have 'uid' at 1337 (istio internal uid). CRIU does not restore uid atm, just adding this to dump side, proto image and using the data on restore.

Note: setfsuid is process-wide call. But I believe CRIU is single-threaded at this stage (well, Claude says that), so it should _not_ be a problem.
Note 2: the test seem to _really_ work. Consider https://github.com/castai/criu/pull/41 (where the restore side is dropped). [The test has failed](https://github.com/castai/criu/actions/runs/25704314751/job/75471040277?pr=41#step:3:17281) - `FAIL: socket-tcp-uid.c:167: post-restore: sk_uid is 0, want 1337 (inode 685980) (errno = 11 (Resource temporarily unavailable))`.

---

istio iptables rules sample

```
# Generated by iptables-save v1.8.11 (nf_tables) on Sun Apr 26 19:15:21 2026
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:ISTIO_INBOUND - [0:0]
:ISTIO_IN_REDIRECT - [0:0]
:ISTIO_OUTPUT - [0:0]
:ISTIO_REDIRECT - [0:0]
-A PREROUTING -p tcp -j ISTIO_INBOUND
-A OUTPUT -j ISTIO_OUTPUT
-A ISTIO_INBOUND -p tcp -m tcp --dport 15008 -j RETURN
-A ISTIO_INBOUND -p tcp -m tcp --dport 15090 -j RETURN
-A ISTIO_INBOUND -p tcp -m tcp --dport 15021 -j RETURN
-A ISTIO_INBOUND -p tcp -m tcp --dport 15020 -j RETURN
-A ISTIO_INBOUND -p tcp -j ISTIO_IN_REDIRECT
-A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006
-A ISTIO_OUTPUT -s 127.0.0.6/32 -o lo -j RETURN
-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -p tcp -m tcp ! --dport 15008 -m owner --uid-owner 1337 -j ISTIO_IN_REDIRECT
-A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 1337 -j RETURN
-A ISTIO_OUTPUT -m owner --uid-owner 1337 -j RETURN
-A ISTIO_OUTPUT ! -d 127.0.0.1/32 -o lo -p tcp -m tcp ! --dport 15008 -m owner --gid-owner 1337 -j ISTIO_IN_REDIRECT
-A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 1337 -j RETURN
-A ISTIO_OUTPUT -m owner --gid-owner 1337 -j RETURN
-A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN
-A ISTIO_OUTPUT -j ISTIO_REDIRECT
-A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001
COMMIT
# Completed on Sun Apr 26 19:15:21 2026
```

---
### Kimchi Summary
### What changed
Preserve the kernel socket owner (`sk_uid`) across checkpoint/restore for INET sockets. During dump CRIU captures the uid from `inet_diag`; during restore it temporarily switches `fsuid` via `setfsuid()` around `socket(2)` so the kernel stamps the correct owner on the new socket.

### Why
The kernel initializes `sk_uid` from `current_fsuid()` at socket creation time and exposes no interface to change it later. Without this, restored sockets are owned by the restore-time fsuid (typically root), breaking netfilter rules such as `xt_owner --uid-owner` that depend on the original socket owner.

### Key changes
- `images/sk-inet.proto`: added optional `uid` field (field 21) to `InetSkEntry` to persist the dumped fsuid.
- `criu/include/sk-inet.h`: added `uid` member to `struct inet_sk_desc`.
- `criu/sk-inet.c`:
  - capture uid from `idiag_uid` in `inet_collect_one()` and from `st_uid` for unconstrained sockets in `gen_uncon_sk()`.
  - populate `ie->uid` and `ie->has_uid` in `do_dump_one_inet_fd()`.
  - in `open_inet_sk()`, call `setfsuid(ie->uid)` before `socket()` and revert immediately after; warn if the fsuid could not be set.
- `test/zdtm/static/socket-tcp-uid.c` (new): ZDTM regression test that creates a socket under a non-root fsuid, verifies the expected `sk_uid` via `/proc/net/tcp` before and after C/R, and checks connection integrity.
- `test/zdtm/static/Makefile` & `socket-tcp-uid.desc`: wired the new test into the build with flavor `h ns` and flags `suid nouser samens`.

### Impact
- Netfilter rules using `xt_owner --uid-owner` now remain valid after restore for checkpointed TCP connections.
- In non-user-namespaced containers (the common Kubernetes case) the dumped uid equals the container-local uid and restores transparently.
- In user-namespaced containers dumped from the host namespace, the captured uid may be an unmapped host uid inside the container’s user namespace; `setfsuid()` will silently fail and a warning is logged so the mismatch is visible.

---
### Kimchi Summary
### What changed
Preserves per-socket ownership (`sk_uid`) for INET sockets across checkpoint/restore by saving the dump-time UID in the CRIU image and temporarily switching the process filesystem UID during socket re-creation.

### Why
The kernel stamps `sk_uid` from `current_fsuid()` at socket creation and provides no interface to change it later. Downstream tooling such as `xt_owner` (`--uid-owner`) netfilter rules depends on this value, so restored sockets must be recreated under their original UIDs to avoid policy mismatches.

### Key changes
- `images/sk-inet.proto`: Added optional `uid` field (id 21) to `inet_sk_entry`.
- `criu/include/sk-inet.h`: Added `uid` member to `struct inet_sk_desc`.
- `criu/sk-inet.c`:
  - Captures socket UID in `gen_uncon_sk()` from `p->stat.st_uid` and in `inet_collect_one()` from `m->idiag_uid`.
  - Serializes `ie.uid` and sets `ie.has_uid` in `do_dump_one_inet_fd()`.
  - In `open_inet_sk()`, calls `setfsuid(ie->uid)` before `socket(2)` and restores the old fsuid immediately afterward so the kernel stamps the correct `sk_uid`.
- `test/zdtm/static/`: Added `socket-tcp-uid` ZDTM test and descriptor (`socket-tcp-uid.c`, `socket-tcp-uid.desc`); registered in `Makefile`. The test creates a TCP socket under a non-root UID and verifies via `/proc/net/tcp` that the UID is preserved before and after C/R.

### Impact
- Restored INET sockets now retain their original `sk_uid`, keeping firewall and network-ownership policies consistent.
- In user-namespaced containers where CRIU dumps from the host namespace, the saved UID may be unmapped inside the container; `setfsuid()` will silently fail in that case and a warning is logged.