### PR TITLE
Istio uid test without fix

### DIFF
--- a/criu/sk-inet.c
+++ b/criu/sk-inet.c
@@ -862,8 +862,6 @@ static int open_inet_sk(struct file_desc *d, int *new_fd)
 	struct inet_sk_info *ii;
 	InetSkEntry *ie;
 	int sk, yes = 1;
-	uid_t old_fsuid = 0;
-	bool restore_fsuid = false;
 
 	if (fle->stage >= FLE_OPEN)
 		return post_open_inet_sk(d, fle->fe->fd);
@@ -903,21 +901,21 @@ static int open_inet_sk(struct file_desc *d, int *new_fd)
 	 * userns and setfsuid will silently not take effect — we log a warning below so the symptom is visible.
 	 */
 	if (ie->has_uid) {
-		old_fsuid = setfsuid(ie->uid);
-		if ((uid_t)setfsuid(-1) != ie->uid)
-			pr_warn("Couldn't set fsuid to %u for inet socket; "
-				"sk_uid will be %u. xt_owner rules may misbehave.\n",
-				ie->uid, old_fsuid);
-		else
-			pr_debug("Creating inet socket with fsuid %u (was %u)\n",
-				 ie->uid, old_fsuid);
-		restore_fsuid = true;
+//		old_fsuid = setfsuid(ie->uid);
+//		if ((uid_t)setfsuid(-1) != ie->uid)
+//			pr_warn("Couldn't set fsuid to %u for inet socket; "
+//				"sk_uid will be %u. xt_owner rules may misbehave.\n",
+//				ie->uid, old_fsuid);
+//		else
+//			pr_debug("Creating inet socket with fsuid %u (was %u)\n",
+//				 ie->uid, old_fsuid);
+//		restore_fsuid = true;
 	}
 
 	sk = socket(ie->family, ie->type, ie->proto);
 
-	if (restore_fsuid)
-		setfsuid(old_fsuid);
+//	if (restore_fsuid)
+//		setfsuid(old_fsuid);
 
 	if (sk < 0) {
 		pr_perror("Can't create inet socket");


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->

---
### Kimchi Summary
### What changed
Adds `uid` capture to inet socket dump and introduces a new ZDTM regression test (`socket-tcp-uid`) that verifies `sk_uid` is preserved across checkpoint/restore.

### Why
The kernel stamps `sk->sk_uid` from `current_fsuid()` at socket creation, and `xt_owner --uid-owner` netfilter rules rely on this value. Preserving it ensures networking policies that match by socket owner continue to work after restore.

### Key changes
- `criu/include/sk-inet.h`: Added `uid` field to `struct inet_sk_desc`.
- `criu/sk-inet.c`:
  - Populates `sk->uid` from `p->stat.st_uid` in `gen_uncon_sk()`.
  - Emits `ie.uid` and `ie.has_uid` into the dump image in `do_dump_one_inet_fd()`.
  - Captures `d->uid` from `m->idiag_uid` in `inet_collect_one()`.
  - Adds commented-out `setfsuid()` scaffolding around `socket()` in `open_inet_sk()` to later restore sockets with their original fsuid.
- `images/sk-inet.proto`: Added optional `uid` field (21) to `inet_sk_entry`.
- `test/zdtm/static/socket-tcp-uid.c` (new): Test that creates an accepted TCP socket under `fsuid = 1337`, checks `/proc/net/tcp` for the expected `sk_uid` before dump, and validates it again after restore.
- `test/zdtm/static/socket-tcp-uid.desc` (new): Test configuration requiring `--tcp-established` and `suid`/`nouser`/`samens` flags.
- `test/zdtm/static/Makefile`: Registered `socket-tcp-uid` in the static build list.

### Impact
- The restore-side `setfsuid()` logic is currently commented out, so while dump-side collection is wired, the full end-to-end uid restoration is not yet active. The new test will fail on restore until that logic is enabled.