### PR TITLE
fix(conntrack): synthesize DNAT/SNAT conntrack entries

### DIFF
--- a/criu/net.c
+++ b/criu/net.c
@@ -1,10 +1,12 @@
 #include <unistd.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/netfilter/nfnetlink.h>
 #include <linux/netfilter/nfnetlink_conntrack.h>
 #include <linux/netfilter/nf_conntrack_tcp.h>
+#include <linux/netfilter/nf_conntrack_common.h>
 #include <string.h>
 #include <net/if_arp.h>
 #include <sys/wait.h>
@@ -941,17 +943,402 @@ static int dump_one_link(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 	return ret;
 }
 
+/*
+ * The kernel's conntrack dump path (IPCTNL_MSG_CT_GET, NLM_F_DUMP) never emits
+ * CTA_NAT_SRC / CTA_NAT_DST — those attributes are input-only, consumed by
+ * IPCTNL_MSG_CT_NEW to bind a NAT extension to the entry. And CTA_STATUS bits
+ * IPS_{SRC,DST}_NAT{,_DONE} are in IPS_UNCHANGEABLE_MASK in the kernel, so
+ * ctnetlink_change_status() silently strips them on replay.
+ *
+ * Result: round-tripping conntrack via dump→restore loses NAT bindings — the
+ * flow is re-tracked but reply packets are no longer reverse-translated,
+ * breaking e.g. Istio's REDIRECT-based sidecar interception across migration.
+ *
+ * The NAT rewrite is recoverable from the two tuples the kernel does emit:
+ *   reply.src <=> post-DNAT form of orig.dst   (when IPS_DST_NAT set)
+ *   reply.dst <=> post-SNAT form of orig.src   (when IPS_SRC_NAT set)
+ *
+ * Synthesize CTA_NAT_SRC/CTA_NAT_DST from this delta at dump time so that the
+ * on-disk message, when replayed through IPCTNL_MSG_CT_NEW, triggers the
+ * kernel's ctnetlink_setup_nat() and re-binds NAT (which in turn sets the
+ * status bits naturally).
+ */
+
+static int nat_nested_from_tuple_ip_port(uint8_t *out, int max, int nest_type,
+					 uint8_t family, const void *ip, uint16_t port_be)
+{
+	struct nlattr *nat_attr, *proto_attr, *ip_attr;
+	int iplen = (family == AF_INET) ? 4 : 16;
+	int ip_min_type = (family == AF_INET) ? CTA_NAT_V4_MINIP : CTA_NAT_V6_MINIP;
+	int ip_max_type = (family == AF_INET) ? CTA_NAT_V4_MAXIP : CTA_NAT_V6_MAXIP;
+	uint8_t *p = out;
+	int len;
+
+	/* outer: CTA_NAT_{SRC,DST} (nested) */
+	if ((int)NLA_HDRLEN > max)
+		return -1;
+	nat_attr = (struct nlattr *)p;
+	nat_attr->nla_type = nest_type | NLA_F_NESTED;
+	p += NLA_HDRLEN;
+
+	/* CTA_NAT_V{4,6}_MINIP */
+	len = NLA_HDRLEN + iplen;
+	if ((p - out) + NLA_ALIGN(len) > max)
+		return -1;
+	ip_attr = (struct nlattr *)p;
+	ip_attr->nla_type = ip_min_type;
+	ip_attr->nla_len = len;
+	memcpy(p + NLA_HDRLEN, ip, iplen);
+	memset(p + NLA_HDRLEN + iplen, 0, NLA_ALIGN(len) - len);
+	p += NLA_ALIGN(len);
+
+	/* CTA_NAT_V{4,6}_MAXIP (same as MINIP — single-value range) */
+	ip_attr = (struct nlattr *)p;
+	ip_attr->nla_type = ip_max_type;
+	ip_attr->nla_len = len;
+	memcpy(p + NLA_HDRLEN, ip, iplen);
+	memset(p + NLA_HDRLEN + iplen, 0, NLA_ALIGN(len) - len);
+	p += NLA_ALIGN(len);
+
+	/* CTA_NAT_PROTO (nested) containing CTA_PROTONAT_PORT_{MIN,MAX} */
+	if ((p - out) + NLA_HDRLEN > max)
+		return -1;
+	proto_attr = (struct nlattr *)p;
+	proto_attr->nla_type = CTA_NAT_PROTO | NLA_F_NESTED;
+	p += NLA_HDRLEN;
+
+	len = NLA_HDRLEN + sizeof(uint16_t);
+	if ((p - out) + 2 * NLA_ALIGN(len) > max)
+		return -1;
+	ip_attr = (struct nlattr *)p;
+	ip_attr->nla_type = CTA_PROTONAT_PORT_MIN;
+	ip_attr->nla_len = len;
+	memcpy(p + NLA_HDRLEN, &port_be, sizeof(uint16_t));
+	memset(p + NLA_HDRLEN + sizeof(uint16_t), 0, NLA_ALIGN(len) - len);
+	p += NLA_ALIGN(len);
+
+	ip_attr = (struct nlattr *)p;
+	ip_attr->nla_type = CTA_PROTONAT_PORT_MAX;
+	ip_attr->nla_len = len;
+	memcpy(p + NLA_HDRLEN, &port_be, sizeof(uint16_t));
+	memset(p + NLA_HDRLEN + sizeof(uint16_t), 0, NLA_ALIGN(len) - len);
+	p += NLA_ALIGN(len);
+
+	proto_attr->nla_len = (p - (uint8_t *)proto_attr);
+	nat_attr->nla_len = (p - (uint8_t *)nat_attr);
+
+	return p - out;
+}
+
+/*
+ * Parse the reply tuple to pull out (family, src_ip, src_port, dst_ip, dst_port)
+ * in the on-wire form. Returns 0 on success, -1 on malformed input.
+ */
+static int parse_reply_tuple(const struct nlattr *tuple_reply, uint8_t *family,
+			     const void **src_ip, uint16_t *src_port,
+			     const void **dst_ip, uint16_t *dst_port)
+{
+	struct nlattr *tb[CTA_TUPLE_MAX + 1];
+	struct nlattr *tb_ip[CTA_IP_MAX + 1];
+	struct nlattr *tb_proto[CTA_PROTO_MAX + 1];
+
+	if (nla_parse_nested(tb, CTA_TUPLE_MAX, (struct nlattr *)tuple_reply, NULL) < 0)
+		return -1;
+	if (!tb[CTA_TUPLE_IP] || !tb[CTA_TUPLE_PROTO])
+		return -1;
+	if (nla_parse_nested(tb_ip, CTA_IP_MAX, tb[CTA_TUPLE_IP], NULL) < 0)
+		return -1;
+	if (nla_parse_nested(tb_proto, CTA_PROTO_MAX, tb[CTA_TUPLE_PROTO], NULL) < 0)
+		return -1;
+
+	if (tb_ip[CTA_IP_V4_SRC] && tb_ip[CTA_IP_V4_DST]) {
+		*family = AF_INET;
+		*src_ip = nla_data(tb_ip[CTA_IP_V4_SRC]);
+		*dst_ip = nla_data(tb_ip[CTA_IP_V4_DST]);
+	} else if (tb_ip[CTA_IP_V6_SRC] && tb_ip[CTA_IP_V6_DST]) {
+		*family = AF_INET6;
+		*src_ip = nla_data(tb_ip[CTA_IP_V6_SRC]);
+		*dst_ip = nla_data(tb_ip[CTA_IP_V6_DST]);
+	} else {
+		return -1;
+	}
+
+	if (!tb_proto[CTA_PROTO_SRC_PORT] || !tb_proto[CTA_PROTO_DST_PORT])
+		return -1;
+
+	*src_port = *(uint16_t *)nla_data(tb_proto[CTA_PROTO_SRC_PORT]);
+	*dst_port = *(uint16_t *)nla_data(tb_proto[CTA_PROTO_DST_PORT]);
+	return 0;
+}
+
+/*
+ * In-place rewrite: make `reply_tuple`'s leaf IP/port fields the inverse of
+ * `orig_tuple` (swap src<->dst). Sizes are identical to the originals, so no
+ * realloc is needed. Used together with synthesized CTA_NAT_*: the kernel's
+ * nf_nat_setup_info() only flips IPS_*_NAT when its computed new_tuple
+ * differs from invert(reply). Sending invert(orig) as the reply (i.e. the
+ * pre-NAT form) guarantees that difference, so the rewrite materializes and
+ * the bits are set as a side effect.
+ */
+static int invert_orig_into_reply(struct nlattr *orig_tuple, struct nlattr *reply_tuple)
+{
+	struct nlattr *o_tb[CTA_TUPLE_MAX + 1], *r_tb[CTA_TUPLE_MAX + 1];
+	struct nlattr *o_ip[CTA_IP_MAX + 1], *r_ip[CTA_IP_MAX + 1];
+	struct nlattr *o_pr[CTA_PROTO_MAX + 1], *r_pr[CTA_PROTO_MAX + 1];
+
+	if (nla_parse_nested(o_tb, CTA_TUPLE_MAX, orig_tuple, NULL) < 0 ||
+	    nla_parse_nested(r_tb, CTA_TUPLE_MAX, reply_tuple, NULL) < 0)
+		return -1;
+	if (!o_tb[CTA_TUPLE_IP] || !o_tb[CTA_TUPLE_PROTO] ||
+	    !r_tb[CTA_TUPLE_IP] || !r_tb[CTA_TUPLE_PROTO])
+		return -1;
+	if (nla_parse_nested(o_ip, CTA_IP_MAX, o_tb[CTA_TUPLE_IP], NULL) < 0 ||
+	    nla_parse_nested(r_ip, CTA_IP_MAX, r_tb[CTA_TUPLE_IP], NULL) < 0)
+		return -1;
+	if (nla_parse_nested(o_pr, CTA_PROTO_MAX, o_tb[CTA_TUPLE_PROTO], NULL) < 0 ||
+	    nla_parse_nested(r_pr, CTA_PROTO_MAX, r_tb[CTA_TUPLE_PROTO], NULL) < 0)
+		return -1;
+
+	if (o_ip[CTA_IP_V4_SRC] && o_ip[CTA_IP_V4_DST] &&
+	    r_ip[CTA_IP_V4_SRC] && r_ip[CTA_IP_V4_DST]) {
+		memcpy(nla_data(r_ip[CTA_IP_V4_SRC]), nla_data(o_ip[CTA_IP_V4_DST]), 4);
+		memcpy(nla_data(r_ip[CTA_IP_V4_DST]), nla_data(o_ip[CTA_IP_V4_SRC]), 4);
+	} else if (o_ip[CTA_IP_V6_SRC] && o_ip[CTA_IP_V6_DST] &&
+		   r_ip[CTA_IP_V6_SRC] && r_ip[CTA_IP_V6_DST]) {
+		memcpy(nla_data(r_ip[CTA_IP_V6_SRC]), nla_data(o_ip[CTA_IP_V6_DST]), 16);
+		memcpy(nla_data(r_ip[CTA_IP_V6_DST]), nla_data(o_ip[CTA_IP_V6_SRC]), 16);
+	} else {
+		return -1;
+	}
+
+	if (!o_pr[CTA_PROTO_SRC_PORT] || !o_pr[CTA_PROTO_DST_PORT] ||
+	    !r_pr[CTA_PROTO_SRC_PORT] || !r_pr[CTA_PROTO_DST_PORT])
+		return -1;
+	memcpy(nla_data(r_pr[CTA_PROTO_SRC_PORT]),
+	       nla_data(o_pr[CTA_PROTO_DST_PORT]), sizeof(uint16_t));
+	memcpy(nla_data(r_pr[CTA_PROTO_DST_PORT]),
+	       nla_data(o_pr[CTA_PROTO_SRC_PORT]), sizeof(uint16_t));
+	return 0;
+}
+
 static int dump_one_nf(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 {
 	struct cr_img *img = arg;
+	struct nfgenmsg *nfm;
+	struct nlattr *tb[CTA_MAX + 1];
+	uint32_t status;
+	uint8_t subsys;
 
 	if (lazy_image(img) && open_image_lazy(img))
 		return -1;
 
+	subsys = hdr->nlmsg_type >> 8;
+
+	/*
+	 * Only conntrack entries carry NAT; expectations go through
+	 * CTNETLINK_EXP which has a separate attr space.
+	 */
+	if (subsys != NFNL_SUBSYS_CTNETLINK)
+		goto write_as_is;
+
+	if (hdr->nlmsg_len < NLMSG_LENGTH(sizeof(struct nfgenmsg)))
+		goto write_as_is;
+
+	nfm = NLMSG_DATA(hdr);
+	if (nfm->nfgen_family != AF_INET && nfm->nfgen_family != AF_INET6)
+		goto write_as_is;
+
+	if (nlmsg_parse(hdr, sizeof(struct nfgenmsg), tb, CTA_MAX, NULL) < 0)
+		goto write_as_is;
+
+	if (!tb[CTA_STATUS] || !tb[CTA_TUPLE_REPLY] || !tb[CTA_TUPLE_ORIG])
+		goto write_as_is;
+
+	status = ntohl(nla_get_u32(tb[CTA_STATUS]));
+	if (!(status & (IPS_SRC_NAT | IPS_DST_NAT)))
+		goto write_as_is;
+
+	/*
+	 * Synthesize CTA_NAT_SRC and/or CTA_NAT_DST into a copy of the
+	 * netlink message. On replay, ctnetlink_setup_nat() will re-bind NAT
+	 * from these attrs (and set the status bits as a side effect).
+	 */
+	{
+		uint8_t family;
+		const void *rsrc_ip, *rdst_ip;
+		uint16_t rsrc_port, rdst_port;
+		struct nlmsghdr *new_hdr;
+		uint32_t old_len;
+		uint8_t appended[256]; /* max 2 * CTA_NAT_* nestings, always fits */
+		int appended_len = 0;
+		int n;
+		int ret;
+
+		if (parse_reply_tuple(tb[CTA_TUPLE_REPLY], &family,
+				      &rsrc_ip, &rsrc_port, &rdst_ip, &rdst_port) < 0)
+			goto write_as_is;
+
+		if (status & IPS_DST_NAT) {
+			/* orig.dst was rewritten; reply.src reveals the rewrite target */
+			n = nat_nested_from_tuple_ip_port(appended + appended_len,
+							  sizeof(appended) - appended_len,
+							  CTA_NAT_DST, family,
+							  rsrc_ip, rsrc_port);
+			if (n < 0)
+				goto write_as_is;
+			appended_len += n;
+		}
+		if (status & IPS_SRC_NAT) {
+			/* orig.src was rewritten; reply.dst reveals the rewrite target */
+			n = nat_nested_from_tuple_ip_port(appended + appended_len,
+							  sizeof(appended) - appended_len,
+							  CTA_NAT_SRC, family,
+							  rdst_ip, rdst_port);
+			if (n < 0)
+				goto write_as_is;
+			appended_len += n;
+		}
+
+		if (appended_len == 0)
+			goto write_as_is;
+
+		old_len = hdr->nlmsg_len;
+		new_hdr = xmalloc(NLMSG_ALIGN(old_len) + appended_len);
+		if (!new_hdr)
+			return -1;
+
+		memcpy(new_hdr, hdr, old_len);
+		/* Pad out to align the appended attrs on a 4-byte boundary. */
+		if (NLMSG_ALIGN(old_len) != old_len)
+			memset((uint8_t *)new_hdr + old_len, 0,
+			       NLMSG_ALIGN(old_len) - old_len);
+		memcpy((uint8_t *)new_hdr + NLMSG_ALIGN(old_len), appended, appended_len);
+		new_hdr->nlmsg_len = NLMSG_ALIGN(old_len) + appended_len;
+
+		/*
+		 * Replace the (post-NAT) reply tuple in the dumped message with
+		 * invert(orig). On replay, that gives ctnetlink_setup_nat() a
+		 * non-trivial range to apply, so the kernel re-derives the
+		 * post-NAT reply tuple from our CTA_NAT_* and sets IPS_*_NAT.
+		 * Without this rewrite, new_tuple == invert(reply) and the
+		 * bit-flipping branch in nf_nat_setup_info() is skipped.
+		 */
+		{
+			struct nlattr *new_tb[CTA_MAX + 1];
+
+			if (nlmsg_parse(new_hdr, sizeof(struct nfgenmsg),
+					new_tb, CTA_MAX, NULL) < 0 ||
+			    !new_tb[CTA_TUPLE_ORIG] || !new_tb[CTA_TUPLE_REPLY] ||
+			    invert_orig_into_reply(new_tb[CTA_TUPLE_ORIG],
+						   new_tb[CTA_TUPLE_REPLY]) < 0) {
+				xfree(new_hdr);
+				goto write_as_is;
+			}
+		}
+
+		ret = write_img_buf(img, new_hdr, new_hdr->nlmsg_len);
+		xfree(new_hdr);
+		return ret;
+	}
+
+write_as_is:
 	if (write_img_buf(img, hdr, hdr->nlmsg_len))
 		return -1;
 
 	return 0;
+}
+
+/*
+ * Decode a single conntrack tuple (CTA_TUPLE_ORIG or CTA_TUPLE_REPLY) into
+ * printable form. src_ip/dst_ip get an INET6_ADDRSTRLEN-sized buffer; ports
+ * are returned in host order. Returns 0 on success, -1 if the tuple is
+ * incomplete or malformed.
+ */
+static int format_ct_tuple(struct nlattr *tuple, uint8_t family,
+			   char *src_ip, char *dst_ip, size_t ip_len,
+			   uint8_t *l4proto, uint16_t *src_port, uint16_t *dst_port)
+{
+	struct nlattr *tb[CTA_TUPLE_MAX + 1];
+	struct nlattr *tb_ip[CTA_IP_MAX + 1];
+	struct nlattr *tb_proto[CTA_PROTO_MAX + 1];
+	const void *src_raw, *dst_raw;
+	int af = (family == AF_INET) ? AF_INET : AF_INET6;
+
+	if (nla_parse_nested(tb, CTA_TUPLE_MAX, tuple, NULL) < 0)
+		return -1;
+	if (!tb[CTA_TUPLE_IP] || !tb[CTA_TUPLE_PROTO])
+		return -1;
+	if (nla_parse_nested(tb_ip, CTA_IP_MAX, tb[CTA_TUPLE_IP], NULL) < 0)
+		return -1;
+	if (nla_parse_nested(tb_proto, CTA_PROTO_MAX, tb[CTA_TUPLE_PROTO], NULL) < 0)
+		return -1;
+
+	if (family == AF_INET) {
+		if (!tb_ip[CTA_IP_V4_SRC] || !tb_ip[CTA_IP_V4_DST])
+			return -1;
+		src_raw = nla_data(tb_ip[CTA_IP_V4_SRC]);
+		dst_raw = nla_data(tb_ip[CTA_IP_V4_DST]);
+	} else {
+		if (!tb_ip[CTA_IP_V6_SRC] || !tb_ip[CTA_IP_V6_DST])
+			return -1;
+		src_raw = nla_data(tb_ip[CTA_IP_V6_SRC]);
+		dst_raw = nla_data(tb_ip[CTA_IP_V6_DST]);
+	}
+
+	if (!inet_ntop(af, src_raw, src_ip, ip_len))
+		return -1;
+	if (!inet_ntop(af, dst_raw, dst_ip, ip_len))
+		return -1;
+
+	*l4proto = tb_proto[CTA_PROTO_NUM] ? nla_get_u8(tb_proto[CTA_PROTO_NUM]) : 0;
+	*src_port = tb_proto[CTA_PROTO_SRC_PORT]
+			    ? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_SRC_PORT])) : 0;
+	*dst_port = tb_proto[CTA_PROTO_DST_PORT]
+			    ? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_DST_PORT])) : 0;
+	return 0;
+}
+
+static void log_ct_entry(struct nlmsghdr *nlh)
+{
+	struct nfgenmsg *nfm;
+	struct nlattr *tb[CTA_MAX + 1];
+	char o_src[INET6_ADDRSTRLEN] = "?", o_dst[INET6_ADDRSTRLEN] = "?";
+	char r_src[INET6_ADDRSTRLEN] = "?", r_dst[INET6_ADDRSTRLEN] = "?";
+	uint8_t o_proto = 0, r_proto = 0;
+	uint16_t o_sp = 0, o_dp = 0, r_sp = 0, r_dp = 0;
+	uint32_t status = 0;
+
+	if (nlh->nlmsg_len < NLMSG_LENGTH(sizeof(*nfm)))
+		return;
+	nfm = NLMSG_DATA(nlh);
+	if (nfm->nfgen_family != AF_INET && nfm->nfgen_family != AF_INET6)
+		return;
+	if (nlmsg_parse(nlh, sizeof(*nfm), tb, CTA_MAX, NULL) < 0)
+		return;
+
+	if (tb[CTA_STATUS])
+		status = ntohl(nla_get_u32(tb[CTA_STATUS]));
+	if (tb[CTA_TUPLE_ORIG])
+		format_ct_tuple(tb[CTA_TUPLE_ORIG], nfm->nfgen_family,
+				o_src, o_dst, sizeof(o_src),
+				&o_proto, &o_sp, &o_dp);
+	if (tb[CTA_TUPLE_REPLY])
+		format_ct_tuple(tb[CTA_TUPLE_REPLY], nfm->nfgen_family,
+				r_src, r_dst, sizeof(r_src),
+				&r_proto, &r_sp, &r_dp);
+
+	pr_debug("CT restore: %s proto=%u orig=%s:%u->%s:%u reply=%s:%u->%s:%u "
+		 "status=0x%08x%s%s%s%s%s%s%s\n",
+		 nfm->nfgen_family == AF_INET ? "v4" : "v6",
+		 o_proto, o_src, o_sp, o_dst, o_dp,
+		 r_src, r_sp, r_dst, r_dp, status,
+		 status & IPS_SEEN_REPLY ? " SEEN_REPLY" : "",
+		 status & IPS_ASSURED ? " ASSURED" : "",
+		 status & IPS_CONFIRMED ? " CONFIRMED" : "",
+		 status & IPS_SRC_NAT ? " SRC_NAT" : "",
+		 status & IPS_DST_NAT ? " DST_NAT" : "",
+		 status & IPS_SRC_NAT_DONE ? " SRC_NAT_DONE" : "",
+		 status & IPS_DST_NAT_DONE ? " DST_NAT_DONE" : "");
 }
 
 static int ct_restore_callback(struct nlmsghdr *nlh)
@@ -1022,6 +1409,12 @@ static int restore_nf_ct(int pid, int type)
 		goto out_img;
 	}
 
+	{
+		int one = 1;
+		if (setsockopt(sk, SOL_NETLINK, NETLINK_EXT_ACK, &one, sizeof(one)) < 0)
+			pr_warn("Can't enable NETLINK_EXT_ACK on conntrack socket: %s\n", strerror(errno));
+	}
+
 	nlh = xmalloc(sizeof(struct nlmsghdr));
 	if (nlh == NULL)
 		goto out;
@@ -1049,14 +1442,33 @@ static int restore_nf_ct(int pid, int type)
 			goto out;
 		}
 
-		if (type == CR_FD_NETNF_CT)
+		if (type == CR_FD_NETNF_CT) {
 			if (ct_restore_callback(nlh))
 				goto out;
+			log_ct_entry(nlh);
+		}
 
 		nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE;
 		ret = do_rtnl_req(sk, nlh, nlh->nlmsg_len, NULL, NULL, NULL, NULL);
-		if (ret)
-			goto out;
+		if (ret) {
+			uint8_t *b = (uint8_t *)nlh;
+			uint32_t len = nlh->nlmsg_len;
+			uint32_t off;
+
+			pr_err("nf_ct restore failed (ret=%d), message len=%u, bytes:\n", ret, len);
+			for (off = 0; off < len; off += 16) {
+				uint32_t i, end = off + 16 < len ? off + 16 : len;
+				char line[3 * 16 + 1];
+				char *p = line;
+
+				for (i = off; i < end; i++)
+					p += sprintf(p, "%02x ", b[i]);
+				*p = '\0';
+				pr_err("  %04x: %s\n", off, line);
+			}
+			/* Don't fail the whole restore if a single entry fails to restore. */
+            ret = 0;
+		}
 	}
 
 	exit_code = 0;

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -98,6 +98,7 @@ TST_NOFILE	:=				\
 		socket-tcp-local		\
 		socket-tcp-reuseport		\
 		socket-tcp-ipt-nfconntrack	\
+		socket-tcp-ipt-redirect-conntrack	\
 		socket-tcp-nft-nfconntrack	\
 		socket-tcp6-local		\
 		socket-tcp4v6-local		\

--- a/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c
+++ b/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c
@@ -1,0 +1,142 @@
+#include "zdtmtst.h"
+
+const char *test_doc = "Check TCP DNAT (iptables REDIRECT) conntrack survives C/R\n";
+const char *test_author = "Dmytro Bainak <dbaynak@protonmail.com>";
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sched.h>
+#include <sys/types.h>
+#include <netinet/tcp.h>
+
+#define BUF_SIZE   4096
+#define REDIR_PORT 12345
+
+int main(int argc, char **argv)
+{
+	unsigned char buf[BUF_SIZE];
+	int fd, fd_s;
+	pid_t extpid;
+	uint32_t crc;
+	int real_port = 8880;
+	char rule[256];
+
+	if (unshare(CLONE_NEWNET)) {
+		pr_perror("unshare");
+		return 1;
+	}
+	if (system("ip link set up dev lo"))
+		return 1;
+
+	/*
+	 * Bring the server up first so we know the real port to point the
+	 * REDIRECT rule at. The connect()ing peer never sees this port -- it
+	 * targets REDIR_PORT and the kernel DNATs.
+	 */
+	if ((fd_s = tcp_init_server(AF_INET, &real_port)) < 0) {
+		pr_err("initializing server failed\n");
+		return 1;
+	}
+
+	snprintf(rule, sizeof(rule),
+		 "iptables-legacy -t nat -w -A OUTPUT -p tcp --dport %d "
+		 "-j REDIRECT --to-ports %d", REDIR_PORT, real_port);
+	if (system(rule))
+		return 1;
+
+	/*
+	 * Force every packet through conntrack so the kernel populates an
+	 * entry with IPS_DST_NAT set (and CTA_NAT_DST on dump). Without the
+	 * DROP fallback, replies could bypass tracking on a hot path.
+	 */
+	if (system("iptables-legacy -w -A INPUT -i lo -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT"))
+		return 1;
+	if (system("iptables-legacy -w -A INPUT -j DROP"))
+		return 1;
+
+	test_init(argc, argv);
+
+	extpid = fork();
+	if (extpid < 0) {
+		pr_perror("fork() failed");
+		return 1;
+	} else if (extpid == 0) {
+		close(fd_s);
+
+		fd = tcp_init_client(AF_INET, "127.0.0.1", REDIR_PORT);
+		if (fd < 0)
+			return 1;
+
+		/* Pre-migration round-trip: server -> client, client -> server. */
+		if (read_data(fd, buf, BUF_SIZE)) {
+			pr_perror("read less than have to (pre)");
+			return 1;
+		}
+		if (datachk(buf, BUF_SIZE, &crc))
+			return 2;
+		datagen(buf, BUF_SIZE, &crc);
+		if (write_data(fd, buf, BUF_SIZE)) {
+			pr_perror("can't write (pre)");
+			return 1;
+		}
+
+		/*
+		 * Post-migration round-trip. If NAT was lost on restore, the
+		 * server's replies arrive with src=real_port but the client's
+		 * socket is connected to REDIR_PORT -- the kernel drops them
+		 * and this read() hangs (test harness times out).
+		 */
+		if (read_data(fd, buf, BUF_SIZE)) {
+			pr_perror("read less than have to (post)");
+			return 1;
+		}
+		if (datachk(buf, BUF_SIZE, &crc))
+			return 2;
+		datagen(buf, BUF_SIZE, &crc);
+		if (write_data(fd, buf, BUF_SIZE)) {
+			pr_perror("can't write (post)");
+			return 1;
+		}
+		return 0;
+	}
+
+	fd = tcp_accept_server(fd_s);
+	if (fd < 0) {
+		pr_err("can't accept client connection\n");
+		return 1;
+	}
+
+	datagen(buf, BUF_SIZE, &crc);
+	if (write_data(fd, buf, BUF_SIZE)) {
+		pr_perror("can't write (pre)");
+		return 1;
+	}
+	if (read_data(fd, buf, BUF_SIZE)) {
+		pr_perror("read less than have to (pre)");
+		return 1;
+	}
+	if (datachk(buf, BUF_SIZE, &crc))
+		return 2;
+
+	test_daemon();
+	test_waitsig();
+
+	datagen(buf, BUF_SIZE, &crc);
+	if (write_data(fd, buf, BUF_SIZE)) {
+		pr_perror("can't write (post)");
+		return 1;
+	}
+	if (read_data(fd, buf, BUF_SIZE)) {
+		pr_perror("read less than have to (post)");
+		return 1;
+	}
+	if (datachk(buf, BUF_SIZE, &crc))
+		return 2;
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.desc
+++ b/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.desc
@@ -1,0 +1,6 @@
+{
+    'feature': 'has_ipt_legacy',
+    'flavor': 'h',
+    'opts': '--tcp-established',
+    'flags': 'suid'
+}


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Preserve NAT bindings in netfilter conntrack across checkpoint/restore by synthesizing `CTA_NAT_SRC` and `CTA_NAT_DST` attributes from the original/reply tuple delta at dump time. Added debug logging for conntrack restore and made individual entry failures non-fatal. Added a ZDTM test covering the iptables `REDIRECT` (DNAT) case.

### Why
The kernel conntrack dump path never emits `CTA_NAT_SRC`/`CTA_NAT_DST`, and on restore the `IPS_SRC_NAT`/`IPS_DST_NAT` status bits are silently stripped. This causes reply packets to stop being reverse-translated after migration, breaking traffic redirection schemes such as Istio's sidecar interception.

### Key changes
- `criu/net.c` — Added helpers `nat_nested_from_tuple_ip_port()`, `parse_reply_tuple()`, `invert_orig_into_reply()`, and `format_ct_tuple()`:
  - `dump_one_nf()` now detects conntrack entries with `IPS_SRC_NAT` or `IPS_DST_NAT`, reconstructs the missing NAT attributes from the reply tuple, rewrites the reply tuple to the inverse of the original, and appends the synthesized attributes to the image.
  - `restore_nf_ct()` enables `NETLINK_EXT_ACK`, logs each restored entry via `log_ct_entry()`, and converts hard restore failures into hex-dumped warnings so one bad entry does not abort the entire network restore.
- Added `test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c` and `.desc` — validates that a TCP connection through an iptables `REDIRECT` rule survives checkpoint/restore.
- `test/zdtm/static/Makefile` — registered the new test target.

### Impact
- NAT conntrack entries now correctly restore their mappings; non-NAT entries are unaffected.
- Individual conntrack restore errors are now logged and skipped instead of failing the whole restore.
- Requires `iptables-legacy` for the new ZDTM test.