### PR TITLE
feat(tcp,conntrack): drop DNAT/SNAT conntrack entries

### DIFF
--- a/criu/net.c
+++ b/criu/net.c
@@ -960,7 +960,7 @@ static int is_nf_dsnat(struct nlmsghdr *hdr)
     if (nlmsg_parse(hdr, sizeof(struct nfgenmsg), tb, CTA_MAX, NULL) < 0)
         return 0;
 
-    if (!tb[CTA_STATUS] || !tb[CTA_TUPLE_REPLY] || !tb[CTA_TUPLE_ORIG])
+    if (!tb[CTA_STATUS])
         return 0;
 
     // skip entries with NAT, we can't restore them properly

--- a/criu/net.c
+++ b/criu/net.c
@@ -943,10 +943,12 @@ static int dump_one_link(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 	return ret;
 }
 
+// == CastAI Live patches ==
 static int is_nf_dsnat(struct nlmsghdr *hdr)
 {
     struct nfgenmsg *nfm;
     struct nlattr *tb[CTA_MAX + 1];
+	uint32_t status;
 
     if (hdr->nlmsg_len < NLMSG_LENGTH(sizeof(struct nfgenmsg)))
         return 0;
@@ -962,9 +964,10 @@ static int is_nf_dsnat(struct nlmsghdr *hdr)
         return 0;
 
     // skip entries with NAT, we can't restore them properly
-    uint32_t status = ntohl(nla_get_u32(tb[CTA_STATUS]));
+    status = ntohl(nla_get_u32(tb[CTA_STATUS]));
     return status & (IPS_SRC_NAT | IPS_DST_NAT);
 }
+// == CastAI Live patches ==
 
 static int dump_one_nf(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 {
@@ -977,7 +980,7 @@ static int dump_one_nf(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 	// Skip conntrack entries with NAT. Kernel strips IPS_SRC_NAT|IPS_DST_NAT flags from such entries,
 	// they are restored as non-NAT entries, pretty much breaking such connections.
     if (is_nf_dsnat(hdr)) {
-        pr_info("Skipping conntrack entry with NAT\n");
+        pr_warn("Skipping conntrack entry with NAT\n");
         return 0;
     }
 	// == CastAI Live patches ==

--- a/criu/net.c
+++ b/criu/net.c
@@ -1,10 +1,12 @@
 #include <unistd.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/netfilter/nfnetlink.h>
 #include <linux/netfilter/nfnetlink_conntrack.h>
 #include <linux/netfilter/nf_conntrack_tcp.h>
+#include <linux/netfilter/nf_conntrack_common.h>
 #include <string.h>
 #include <net/if_arp.h>
 #include <sys/wait.h>
@@ -941,12 +943,44 @@ static int dump_one_link(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 	return ret;
 }
 
+static int is_nf_dsnat(struct nlmsghdr *hdr)
+{
+    struct nfgenmsg *nfm;
+    struct nlattr *tb[CTA_MAX + 1];
+
+    if (hdr->nlmsg_len < NLMSG_LENGTH(sizeof(struct nfgenmsg)))
+        return 0;
+
+    nfm = NLMSG_DATA(hdr);
+    if (nfm->nfgen_family != AF_INET && nfm->nfgen_family != AF_INET6)
+        return 0;
+
+    if (nlmsg_parse(hdr, sizeof(struct nfgenmsg), tb, CTA_MAX, NULL) < 0)
+        return 0;
+
+    if (!tb[CTA_STATUS] || !tb[CTA_TUPLE_REPLY] || !tb[CTA_TUPLE_ORIG])
+        return 0;
+
+    // skip entries with NAT, we can't restore them properly
+    uint32_t status = ntohl(nla_get_u32(tb[CTA_STATUS]));
+    return status & (IPS_SRC_NAT | IPS_DST_NAT);
+}
+
 static int dump_one_nf(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 {
 	struct cr_img *img = arg;
 
 	if (lazy_image(img) && open_image_lazy(img))
 		return -1;
+
+	// == CastAI Live patches ==
+	// Skip conntrack entries with NAT. Kernel strips IPS_SRC_NAT|IPS_DST_NAT flags from such entries,
+	// they are restored as non-NAT entries, pretty much breaking such connections.
+    if (is_nf_dsnat(hdr)) {
+        pr_info("Skipping conntrack entry with NAT\n");
+        return 0;
+    }
+	// == CastAI Live patches ==
 
 	if (write_img_buf(img, hdr, hdr->nlmsg_len))
 		return -1;


### PR DESCRIPTION
The kernel strips `IPS_SRC_NAT | IPS_DST_NAT` flags when we manually create a conntrack entry. Such created conntrack entry is just broken. The connection gets **stuck** (no packet flowing on one(*) side, not even a TCP_RST; the other side breaks). 

(*) - I don't remember which one, to be honest.

I am unaware of any good approach to create conntrack entries so `IPS_DST_NAT` is actually set on it.
Restoring a DNATted (iptables REDIRECT) connection WITHOUT its conntrack entries has '50/50' success rate - the connection either breaks immediately, or it resumes without issues (**).

(**):
1. 