### PR TITLE
fix(conntrack): synthesize DNAT/SNAT conntrack entries

### DIFF
--- a/criu/Makefile.crtools
+++ b/criu/Makefile.crtools
@@ -46,6 +46,7 @@ obj-y			+= filesystems.o
 obj-y			+= namespaces.o
 obj-y			+= netfilter.o
 obj-y			+= net.o
+obj-y			+= net-clm-conntrack.o
 obj-y			+= pagemap-cache.o
 obj-y			+= page-pipe.o
 obj-y			+= pagemap.o

--- a/criu/include/net-clm-conntrack.h
+++ b/criu/include/net-clm-conntrack.h
@@ -1,0 +1,14 @@
+#ifndef __CRIU_NET_CLM_CONNTRACK_H__
+#define __CRIU_NET_CLM_CONNTRACK_H__
+
+#include <linux/netlink.h>
+
+struct ns_id;
+
+int is_nf_dsnat(struct nlmsghdr *hdr);
+
+int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg);
+
+void log_ct_entry(struct nlmsghdr *nlh);
+
+#endif /* __CRIU_NET_CLM_CONNTRACK_H__ */

--- a/criu/net-clm-conntrack.c
+++ b/criu/net-clm-conntrack.c
@@ -1,0 +1,391 @@
+#include <arpa/inet.h>
+#include <linux/netfilter/nfnetlink_conntrack.h>
+#include <linux/netfilter/nf_conntrack_tcp.h>
+#include <linux/netfilter/nf_conntrack_common.h>
+#include <libnl3/netlink/attr.h>
+#include <libnl3/netlink/msg.h>
+
+#include "imgset.h"
+#include "util.h"
+#include "net-clm-conntrack.h"
+
+/*
+ * The kernel's conntrack dump path (IPCTNL_MSG_CT_GET, NLM_F_DUMP) never emits
+ * CTA_NAT_SRC / CTA_NAT_DST — those attributes are input-only, consumed by
+ * IPCTNL_MSG_CT_NEW to bind a NAT extension to the entry. And CTA_STATUS bits
+ * IPS_{SRC,DST}_NAT{,_DONE} are in IPS_UNCHANGEABLE_MASK in the kernel, so
+ * ctnetlink_change_status() silently strips them on replay.
+ *
+ * Result: round-tripping conntrack via dump→restore loses NAT bindings — the
+ * flow is re-tracked but reply packets are no longer reverse-translated,
+ * breaking e.g. Istio's REDIRECT-based sidecar interception across migration.
+ *
+ * The NAT rewrite is recoverable from the two tuples the kernel does emit:
+ *   reply.src <=> post-DNAT form of orig.dst   (when IPS_DST_NAT set)
+ *   reply.dst <=> post-SNAT form of orig.src   (when IPS_SRC_NAT set)
+ *
+ * Synthesize CTA_NAT_SRC/CTA_NAT_DST from this delta at dump time so that the
+ * on-disk message, when replayed through IPCTNL_MSG_CT_NEW, triggers the
+ * kernel's ctnetlink_setup_nat() and re-binds NAT (which in turn sets the
+ * status bits naturally).
+ */
+
+static int nat_nested_from_tuple_ip_port(uint8_t *out, int max, int nest_type,
+					  uint8_t family, const void *ip, uint16_t port_be)
+{
+	struct nlattr *nat_attr, *proto_attr, *ip_attr;
+	int iplen = (family == AF_INET) ? 4 : 16;
+	int ip_min_type = (family == AF_INET) ? CTA_NAT_V4_MINIP : CTA_NAT_V6_MINIP;
+	int ip_max_type = (family == AF_INET) ? CTA_NAT_V4_MAXIP : CTA_NAT_V6_MAXIP;
+	uint8_t *p = out;
+	int len;
+
+	/* outer: CTA_NAT_{SRC,DST} (nested) */
+	if ((int)NLA_HDRLEN > max)
+		return -1;
+	nat_attr = (struct nlattr *)p;
+	nat_attr->nla_type = nest_type | NLA_F_NESTED;
+	p += NLA_HDRLEN;
+
+	/* CTA_NAT_V{4,6}_MINIP */
+	len = NLA_HDRLEN + iplen;
+	if ((p - out) + NLA_ALIGN(len) > max)
+		return -1;
+	ip_attr = (struct nlattr *)p;
+	ip_attr->nla_type = ip_min_type;
+	ip_attr->nla_len = len;
+	memcpy(p + NLA_HDRLEN, ip, iplen);
+	memset(p + NLA_HDRLEN + iplen, 0, NLA_ALIGN(len) - len);
+	p += NLA_ALIGN(len);
+
+	/* CTA_NAT_V{4,6}_MAXIP (same as MINIP — single-value range) */
+	ip_attr = (struct nlattr *)p;
+	ip_attr->nla_type = ip_max_type;
+	ip_attr->nla_len = len;
+	memcpy(p + NLA_HDRLEN, ip, iplen);
+	memset(p + NLA_HDRLEN + iplen, 0, NLA_ALIGN(len) - len);
+	p += NLA_ALIGN(len);
+
+	/* CTA_NAT_PROTO (nested) containing CTA_PROTONAT_PORT_{MIN,MAX} */
+	if ((p - out) + NLA_HDRLEN > max)
+		return -1;
+	proto_attr = (struct nlattr *)p;
+	proto_attr->nla_type = CTA_NAT_PROTO | NLA_F_NESTED;
+	p += NLA_HDRLEN;
+
+	len = NLA_HDRLEN + sizeof(uint16_t);
+	if ((p - out) + 2 * NLA_ALIGN(len) > max)
+		return -1;
+	ip_attr = (struct nlattr *)p;
+	ip_attr->nla_type = CTA_PROTONAT_PORT_MIN;
+	ip_attr->nla_len = len;
+	memcpy(p + NLA_HDRLEN, &port_be, sizeof(uint16_t));
+	memset(p + NLA_HDRLEN + sizeof(uint16_t), 0, NLA_ALIGN(len) - len);
+	p += NLA_ALIGN(len);
+
+	ip_attr = (struct nlattr *)p;
+	ip_attr->nla_type = CTA_PROTONAT_PORT_MAX;
+	ip_attr->nla_len = len;
+	memcpy(p + NLA_HDRLEN, &port_be, sizeof(uint16_t));
+	memset(p + NLA_HDRLEN + sizeof(uint16_t), 0, NLA_ALIGN(len) - len);
+	p += NLA_ALIGN(len);
+
+	proto_attr->nla_len = (p - (uint8_t *)proto_attr);
+	nat_attr->nla_len = (p - (uint8_t *)nat_attr);
+
+	return p - out;
+}
+
+/*
+ * Parse the reply tuple to pull out (family, src_ip, src_port, dst_ip, dst_port)
+ * in the on-wire form. Returns 0 on success, -1 on malformed input.
+ */
+static int parse_reply_tuple(const struct nlattr *tuple_reply, uint8_t *family,
+			     const void **src_ip, uint16_t *src_port,
+			     const void **dst_ip, uint16_t *dst_port)
+{
+	struct nlattr *tb[CTA_TUPLE_MAX + 1];
+	struct nlattr *tb_ip[CTA_IP_MAX + 1];
+	struct nlattr *tb_proto[CTA_PROTO_MAX + 1];
+
+	if (nla_parse_nested(tb, CTA_TUPLE_MAX, (struct nlattr *)tuple_reply, NULL) < 0)
+		return -1;
+	if (!tb[CTA_TUPLE_IP] || !tb[CTA_TUPLE_PROTO])
+		return -1;
+	if (nla_parse_nested(tb_ip, CTA_IP_MAX, tb[CTA_TUPLE_IP], NULL) < 0)
+		return -1;
+	if (nla_parse_nested(tb_proto, CTA_PROTO_MAX, tb[CTA_TUPLE_PROTO], NULL) < 0)
+		return -1;
+
+	if (tb_ip[CTA_IP_V4_SRC] && tb_ip[CTA_IP_V4_DST]) {
+		*family = AF_INET;
+		*src_ip = nla_data(tb_ip[CTA_IP_V4_SRC]);
+		*dst_ip = nla_data(tb_ip[CTA_IP_V4_DST]);
+	} else if (tb_ip[CTA_IP_V6_SRC] && tb_ip[CTA_IP_V6_DST]) {
+		*family = AF_INET6;
+		*src_ip = nla_data(tb_ip[CTA_IP_V6_SRC]);
+		*dst_ip = nla_data(tb_ip[CTA_IP_V6_DST]);
+	} else {
+		return -1;
+	}
+
+	if (!tb_proto[CTA_PROTO_SRC_PORT] || !tb_proto[CTA_PROTO_DST_PORT])
+		return -1;
+
+	*src_port = *(uint16_t *)nla_data(tb_proto[CTA_PROTO_SRC_PORT]);
+	*dst_port = *(uint16_t *)nla_data(tb_proto[CTA_PROTO_DST_PORT]);
+	return 0;
+}
+
+/*
+ * In-place rewrite: make `reply_tuple`'s leaf IP/port fields the inverse of
+ * `orig_tuple` (swap src<->dst). Sizes are identical to the originals, so no
+ * realloc is needed. Used together with synthesized CTA_NAT_*: the kernel's
+ * nf_nat_setup_info() only flips IPS_*_NAT when its computed new_tuple
+ * differs from invert(reply). Sending invert(orig) as the reply (i.e. the
+ * pre-NAT form) guarantees that difference, so the rewrite materializes and
+ * the bits are set as a side effect.
+ */
+static int invert_orig_into_reply(struct nlattr *orig_tuple, struct nlattr *reply_tuple)
+{
+	struct nlattr *o_tb[CTA_TUPLE_MAX + 1], *r_tb[CTA_TUPLE_MAX + 1];
+	struct nlattr *o_ip[CTA_IP_MAX + 1], *r_ip[CTA_IP_MAX + 1];
+	struct nlattr *o_pr[CTA_PROTO_MAX + 1], *r_pr[CTA_PROTO_MAX + 1];
+
+	if (nla_parse_nested(o_tb, CTA_TUPLE_MAX, orig_tuple, NULL) < 0 ||
+	    nla_parse_nested(r_tb, CTA_TUPLE_MAX, reply_tuple, NULL) < 0)
+		return -1;
+	if (!o_tb[CTA_TUPLE_IP] || !o_tb[CTA_TUPLE_PROTO] ||
+	    !r_tb[CTA_TUPLE_IP] || !r_tb[CTA_TUPLE_PROTO])
+		return -1;
+	if (nla_parse_nested(o_ip, CTA_IP_MAX, o_tb[CTA_TUPLE_IP], NULL) < 0 ||
+	    nla_parse_nested(r_ip, CTA_IP_MAX, r_tb[CTA_TUPLE_IP], NULL) < 0)
+		return -1;
+	if (nla_parse_nested(o_pr, CTA_PROTO_MAX, o_tb[CTA_TUPLE_PROTO], NULL) < 0 ||
+	    nla_parse_nested(r_pr, CTA_PROTO_MAX, r_tb[CTA_TUPLE_PROTO], NULL) < 0)
+		return -1;
+
+	if (o_ip[CTA_IP_V4_SRC] && o_ip[CTA_IP_V4_DST] && r_ip[CTA_IP_V4_SRC] && r_ip[CTA_IP_V4_DST]) {
+		memcpy(nla_data(r_ip[CTA_IP_V4_SRC]), nla_data(o_ip[CTA_IP_V4_DST]), 4);
+		memcpy(nla_data(r_ip[CTA_IP_V4_DST]), nla_data(o_ip[CTA_IP_V4_SRC]), 4);
+	} else if (o_ip[CTA_IP_V6_SRC] && o_ip[CTA_IP_V6_DST] && r_ip[CTA_IP_V6_SRC] && r_ip[CTA_IP_V6_DST]) {
+		memcpy(nla_data(r_ip[CTA_IP_V6_SRC]), nla_data(o_ip[CTA_IP_V6_DST]), 16);
+		memcpy(nla_data(r_ip[CTA_IP_V6_DST]), nla_data(o_ip[CTA_IP_V6_SRC]), 16);
+	} else {
+		return -1;
+	}
+
+	if (!o_pr[CTA_PROTO_SRC_PORT] || !o_pr[CTA_PROTO_DST_PORT] ||
+	    !r_pr[CTA_PROTO_SRC_PORT] || !r_pr[CTA_PROTO_DST_PORT])
+		return -1;
+	memcpy(nla_data(r_pr[CTA_PROTO_SRC_PORT]),
+	       nla_data(o_pr[CTA_PROTO_DST_PORT]), sizeof(uint16_t));
+	memcpy(nla_data(r_pr[CTA_PROTO_DST_PORT]),
+	       nla_data(o_pr[CTA_PROTO_SRC_PORT]), sizeof(uint16_t));
+	return 0;
+}
+
+int is_nf_dsnat(struct nlmsghdr *hdr)
+{
+	struct nfgenmsg *nfm;
+	struct nlattr *tb[CTA_MAX + 1];
+	uint32_t status;
+
+	if (hdr->nlmsg_len < NLMSG_LENGTH(sizeof(struct nfgenmsg)))
+		return 0;
+
+	nfm = NLMSG_DATA(hdr);
+	if (nfm->nfgen_family != AF_INET && nfm->nfgen_family != AF_INET6)
+		return 0;
+
+	if (nlmsg_parse(hdr, sizeof(struct nfgenmsg), tb, CTA_MAX, NULL) < 0)
+		return 0;
+
+	if (!tb[CTA_STATUS])
+		return 0;
+
+	/* skip entries with NAT, we can't restore them properly */
+	status = ntohl(nla_get_u32(tb[CTA_STATUS]));
+	return status & (IPS_SRC_NAT | IPS_DST_NAT);
+}
+
+// dump_one_nf_dsnat dumps the given conntrack entry with synthesized CTA_NAT_SRC/CTA_NAT_DST if it's a D/SNAT entry.
+// It returns 0 if the entry was successfully dumped.
+// It returns 1 if the entry was NOT dumped AND the entry must be dumped by the caller.
+// It returns <0 on error.
+int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
+{
+	struct nlattr *tb[CTA_MAX + 1];
+	uint8_t family;
+	const void *rsrc_ip, *rdst_ip;
+	uint16_t rsrc_port, rdst_port;
+	struct nlmsghdr *new_hdr;
+	uint32_t old_len;
+	uint8_t appended[4096]; /* max 2 * CTA_NAT_* nestings, always fits */
+	int appended_len = 0;
+	int n;
+	int ret;
+	uint32_t status;
+
+	if (nlmsg_parse(hdr, sizeof(struct nfgenmsg), tb, CTA_MAX, NULL) < 0)
+		return 1;
+
+	if (!tb[CTA_STATUS])
+		return 1;
+
+	status = ntohl(nla_get_u32(tb[CTA_STATUS]));
+
+	if (parse_reply_tuple(tb[CTA_TUPLE_REPLY], &family, &rsrc_ip, &rsrc_port, &rdst_ip, &rdst_port) < 0)
+		return 1;
+
+	if (status & IPS_DST_NAT) {
+		/* orig.dst was rewritten; reply.src reveals the rewrite target */
+		n = nat_nested_from_tuple_ip_port(appended + appended_len,
+				sizeof(appended) - appended_len, CTA_NAT_DST,
+				family, rsrc_ip, rsrc_port);
+		if (n < 0)
+			return 1;
+		appended_len += n;
+	}
+	if (status & IPS_SRC_NAT) {
+		/* orig.src was rewritten; reply.dst reveals the rewrite target */
+		n = nat_nested_from_tuple_ip_port(appended + appended_len,
+				sizeof(appended) - appended_len, CTA_NAT_SRC,
+				family, rdst_ip, rdst_port);
+		if (n < 0)
+			return 1;
+		appended_len += n;
+	}
+
+	if (appended_len == 0)
+		return 1;
+
+	old_len = hdr->nlmsg_len;
+	new_hdr = xmalloc(NLMSG_ALIGN(old_len) + appended_len);
+	if (!new_hdr)
+		return -1;
+
+	memcpy(new_hdr, hdr, old_len);
+	/* Pad out to align the appended attrs on a 4-byte boundary. */
+	if (NLMSG_ALIGN(old_len) != old_len)
+		memset((uint8_t *)new_hdr + old_len, 0, NLMSG_ALIGN(old_len) - old_len);
+	memcpy((uint8_t *)new_hdr + NLMSG_ALIGN(old_len), appended, appended_len);
+	new_hdr->nlmsg_len = NLMSG_ALIGN(old_len) + appended_len;
+
+	/*
+	 * Replace the (post-NAT) reply tuple in the dumped message with
+	 * invert(orig). On replay, that gives ctnetlink_setup_nat() a
+	 * non-trivial range to apply, so the kernel re-derives the post-NAT
+	 * reply tuple from our CTA_NAT_* and sets IPS_*_NAT. Without this
+	 * rewrite, new_tuple == invert(reply) and the bit-flipping branch in
+	 * nf_nat_setup_info() is skipped.
+	 */
+	{
+		struct nlattr *new_tb[CTA_MAX + 1];
+
+		if (nlmsg_parse(new_hdr, sizeof(struct nfgenmsg), new_tb, CTA_MAX, NULL) < 0 ||
+		    !new_tb[CTA_TUPLE_ORIG] || !new_tb[CTA_TUPLE_REPLY] ||
+		    invert_orig_into_reply(new_tb[CTA_TUPLE_ORIG], new_tb[CTA_TUPLE_REPLY]) < 0) {
+			xfree(new_hdr);
+			return 1;
+		}
+	}
+
+	ret = write_img_buf((struct cr_img *)arg, new_hdr, new_hdr->nlmsg_len);
+	xfree(new_hdr);
+	return ret;
+}
+
+/*
+ * Decode a single conntrack tuple (CTA_TUPLE_ORIG or CTA_TUPLE_REPLY) into
+ * printable form. src_ip/dst_ip get an INET6_ADDRSTRLEN-sized buffer; ports
+ * are returned in host order. Returns 0 on success, -1 if the tuple is
+ * incomplete or malformed.
+ */
+static int format_ct_tuple(struct nlattr *tuple, uint8_t family,
+			   char *src_ip, char *dst_ip, size_t ip_len,
+			   uint8_t *l4proto, uint16_t *src_port,
+			   uint16_t *dst_port)
+{
+	struct nlattr *tb[CTA_TUPLE_MAX + 1];
+	struct nlattr *tb_ip[CTA_IP_MAX + 1];
+	struct nlattr *tb_proto[CTA_PROTO_MAX + 1];
+	const void *src_raw, *dst_raw;
+	int af = (family == AF_INET) ? AF_INET : AF_INET6;
+
+	if (nla_parse_nested(tb, CTA_TUPLE_MAX, tuple, NULL) < 0)
+		return -1;
+	if (!tb[CTA_TUPLE_IP] || !tb[CTA_TUPLE_PROTO])
+		return -1;
+	if (nla_parse_nested(tb_ip, CTA_IP_MAX, tb[CTA_TUPLE_IP], NULL) < 0)
+		return -1;
+	if (nla_parse_nested(tb_proto, CTA_PROTO_MAX, tb[CTA_TUPLE_PROTO], NULL) < 0)
+		return -1;
+
+	if (family == AF_INET) {
+		if (!tb_ip[CTA_IP_V4_SRC] || !tb_ip[CTA_IP_V4_DST])
+			return -1;
+		src_raw = nla_data(tb_ip[CTA_IP_V4_SRC]);
+		dst_raw = nla_data(tb_ip[CTA_IP_V4_DST]);
+	} else {
+		if (!tb_ip[CTA_IP_V6_SRC] || !tb_ip[CTA_IP_V6_DST])
+			return -1;
+		src_raw = nla_data(tb_ip[CTA_IP_V6_SRC]);
+		dst_raw = nla_data(tb_ip[CTA_IP_V6_DST]);
+	}
+
+	if (!inet_ntop(af, src_raw, src_ip, ip_len))
+		return -1;
+	if (!inet_ntop(af, dst_raw, dst_ip, ip_len))
+		return -1;
+
+	*l4proto = tb_proto[CTA_PROTO_NUM] ? nla_get_u8(tb_proto[CTA_PROTO_NUM]) : 0;
+	*src_port = tb_proto[CTA_PROTO_SRC_PORT]
+				? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_SRC_PORT])) : 0;
+	*dst_port = tb_proto[CTA_PROTO_DST_PORT]
+				? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_DST_PORT])) : 0;
+	return 0;
+}
+
+void log_ct_entry(struct nlmsghdr *nlh)
+{
+	struct nfgenmsg *nfm;
+	struct nlattr *tb[CTA_MAX + 1];
+	char o_src[INET6_ADDRSTRLEN] = "?", o_dst[INET6_ADDRSTRLEN] = "?";
+	char r_src[INET6_ADDRSTRLEN] = "?", r_dst[INET6_ADDRSTRLEN] = "?";
+	uint8_t o_proto = 0, r_proto = 0;
+	uint16_t o_sp = 0, o_dp = 0, r_sp = 0, r_dp = 0;
+	uint32_t status = 0;
+
+	if (nlh->nlmsg_len < NLMSG_LENGTH(sizeof(*nfm)))
+		return;
+	nfm = NLMSG_DATA(nlh);
+	if (nfm->nfgen_family != AF_INET && nfm->nfgen_family != AF_INET6)
+		return;
+	if (nlmsg_parse(nlh, sizeof(*nfm), tb, CTA_MAX, NULL) < 0)
+		return;
+
+	if (tb[CTA_STATUS])
+		status = ntohl(nla_get_u32(tb[CTA_STATUS]));
+	if (tb[CTA_TUPLE_ORIG])
+		format_ct_tuple(tb[CTA_TUPLE_ORIG], nfm->nfgen_family,
+				o_src, o_dst, sizeof(o_src),
+				&o_proto, &o_sp, &o_dp);
+	if (tb[CTA_TUPLE_REPLY])
+		format_ct_tuple(tb[CTA_TUPLE_REPLY], nfm->nfgen_family,
+				r_src, r_dst, sizeof(r_src),
+				&r_proto, &r_sp, &r_dp);
+
+	pr_err("CT restore: %s proto=%u orig=%s:%u->%s:%u reply=%s:%u->%s:%u "
+	       "status=0x%08x%s%s%s%s%s%s%s\n",
+	       nfm->nfgen_family == AF_INET ? "v4" : "v6",
+	       o_proto, o_src, o_sp, o_dst, o_dp,
+	       r_src, r_sp, r_dst, r_dp, status,
+	       status & IPS_SEEN_REPLY ? " SEEN_REPLY" : "",
+	       status & IPS_ASSURED ? " ASSURED" : "",
+	       status & IPS_CONFIRMED ? " CONFIRMED" : "",
+	       status & IPS_SRC_NAT ? " SRC_NAT" : "",
+	       status & IPS_DST_NAT ? " DST_NAT" : "",
+	       status & IPS_SRC_NAT_DONE ? " SRC_NAT_DONE" : "",
+	       status & IPS_DST_NAT_DONE ? " DST_NAT_DONE" : "");
+}

--- a/criu/net-clm-conntrack.c
+++ b/criu/net-clm-conntrack.c
@@ -240,7 +240,7 @@ int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 	if (nlmsg_parse(hdr, sizeof(struct nfgenmsg), tb, CTA_MAX, NULL) < 0)
 		return 1;
 
-	if (!tb[CTA_STATUS])
+	if (!tb[CTA_STATUS] || !tb[CTA_TUPLE_REPLY] || !tb[CTA_TUPLE_ORIG])
 		return 1;
 
 	status = ntohl(nla_get_u32(tb[CTA_STATUS]));

--- a/criu/net-clm-conntrack.c
+++ b/criu/net-clm-conntrack.c
@@ -29,7 +29,6 @@
  * kernel's ctnetlink_setup_nat() and re-binds NAT (which in turn sets the
  * status bits naturally).
  */
-
 static int nat_nested_from_tuple_ip_port(uint8_t *out, int max, int nest_type,
 					  uint8_t family, const void *ip, uint16_t port_be)
 {
@@ -138,13 +137,13 @@ static int parse_reply_tuple(const struct nlattr *tuple_reply, uint8_t *family,
 }
 
 /*
- * In-place rewrite: make `reply_tuple`'s leaf IP/port fields the inverse of
- * `orig_tuple` (swap src<->dst). Sizes are identical to the originals, so no
- * realloc is needed. Used together with synthesized CTA_NAT_*: the kernel's
- * nf_nat_setup_info() only flips IPS_*_NAT when its computed new_tuple
- * differs from invert(reply). Sending invert(orig) as the reply (i.e. the
- * pre-NAT form) guarantees that difference, so the rewrite materializes and
- * the bits are set as a side effect.
+ * In-place rewrite: make `reply_tuple`'s leaf IP/port fields the inverse of `orig_tuple` (swap src<->dst).
+ * Sizes are identical to the originals, so no realloc is needed.
+ *
+ * Used together with synthesized CTA_NAT_*: the kernel's nf_nat_setup_info() only flips IPS_*_NAT
+ * when its computed new_tuple differs from invert(reply).
+ * Sending invert(orig) as the reply (i.e. the pre-NAT form) guarantees that difference,
+ * so the rewrite materializes and the bits are set as a side effect.
  */
 static int invert_orig_into_reply(struct nlattr *orig_tuple, struct nlattr *reply_tuple)
 {
@@ -273,12 +272,10 @@ int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 	new_hdr->nlmsg_len = NLMSG_ALIGN(old_len) + appended_len;
 
 	/*
-	 * Replace the (post-NAT) reply tuple in the dumped message with
-	 * invert(orig). On replay, that gives ctnetlink_setup_nat() a
-	 * non-trivial range to apply, so the kernel re-derives the post-NAT
-	 * reply tuple from our CTA_NAT_* and sets IPS_*_NAT. Without this
-	 * rewrite, new_tuple == invert(reply) and the bit-flipping branch in
-	 * nf_nat_setup_info() is skipped.
+	 * Replace the (post-NAT) reply tuple in the dumped message with invert(orig).
+	 * On replay, that gives ctnetlink_setup_nat() a non-trivial range to apply,
+	 * so the kernel re-derives the post-NAT reply tuple from our CTA_NAT_* and sets IPS_*_NAT.
+	 * Without this rewrite, new_tuple == invert(reply) and the bit-flipping¸ the branch in nf_nat_setup_info() is skipped.
 	 */
 	{
 		struct nlattr *new_tb[CTA_MAX + 1];

--- a/criu/net-clm-conntrack.c
+++ b/criu/net-clm-conntrack.c
@@ -102,18 +102,26 @@ static int nat_nested_from_tuple_ip_port(uint8_t *out, int max, int nest_type,
 }
 
 /*
- * Parse a 'tuple-attrs' to pull out (family, src_ip, src_port, dst_ip, dst_port) in the on-wire form.
- * Returns 0 on success, -1 on malformed input.
+ * Raw decoded view of a CTA_TUPLE_{ORIG,REPLY}.
+ * Ports stay in network byte order — callers ntohs() if they want host order.
+ * IP pointers reference int the original netlink buffer.
  */
-static int parse_tuple_attrs(const struct nlattr *tuple_reply, uint8_t *family,
-			     const void **src_ip, uint16_t *src_port,
-			     const void **dst_ip, uint16_t *dst_port)
+struct ct_tuple_view {
+	uint8_t family;
+	uint8_t l4proto;
+	const void *src_ip;
+	const void *dst_ip;
+	uint16_t src_port_be;
+	uint16_t dst_port_be;
+};
+
+static int decode_ct_tuple(struct nlattr *tuple, struct ct_tuple_view *v)
 {
 	struct nlattr *tb[CTA_TUPLE_MAX + 1];
 	struct nlattr *tb_ip[CTA_IP_MAX + 1];
 	struct nlattr *tb_proto[CTA_PROTO_MAX + 1];
 
-	if (nla_parse_nested(tb, CTA_TUPLE_MAX, (struct nlattr *)tuple_reply, NULL) < 0)
+	if (nla_parse_nested(tb, CTA_TUPLE_MAX, tuple, NULL) < 0)
 		return -1;
 	if (!tb[CTA_TUPLE_IP] || !tb[CTA_TUPLE_PROTO])
 		return -1;
@@ -123,13 +131,13 @@ static int parse_tuple_attrs(const struct nlattr *tuple_reply, uint8_t *family,
 		return -1;
 
 	if (tb_ip[CTA_IP_V4_SRC] && tb_ip[CTA_IP_V4_DST]) {
-		*family = AF_INET;
-		*src_ip = nla_data(tb_ip[CTA_IP_V4_SRC]);
-		*dst_ip = nla_data(tb_ip[CTA_IP_V4_DST]);
+		v->family = AF_INET;
+		v->src_ip = nla_data(tb_ip[CTA_IP_V4_SRC]);
+		v->dst_ip = nla_data(tb_ip[CTA_IP_V4_DST]);
 	} else if (tb_ip[CTA_IP_V6_SRC] && tb_ip[CTA_IP_V6_DST]) {
-		*family = AF_INET6;
-		*src_ip = nla_data(tb_ip[CTA_IP_V6_SRC]);
-		*dst_ip = nla_data(tb_ip[CTA_IP_V6_DST]);
+		v->family = AF_INET6;
+		v->src_ip = nla_data(tb_ip[CTA_IP_V6_SRC]);
+		v->dst_ip = nla_data(tb_ip[CTA_IP_V6_DST]);
 	} else {
 		return -1;
 	}
@@ -137,8 +145,9 @@ static int parse_tuple_attrs(const struct nlattr *tuple_reply, uint8_t *family,
 	if (!tb_proto[CTA_PROTO_SRC_PORT] || !tb_proto[CTA_PROTO_DST_PORT])
 		return -1;
 
-	*src_port = *(uint16_t *)nla_data(tb_proto[CTA_PROTO_SRC_PORT]);
-	*dst_port = *(uint16_t *)nla_data(tb_proto[CTA_PROTO_DST_PORT]);
+	v->l4proto = tb_proto[CTA_PROTO_NUM] ? nla_get_u8(tb_proto[CTA_PROTO_NUM]) : 0;
+	v->src_port_be = *(uint16_t *)nla_data(tb_proto[CTA_PROTO_SRC_PORT]);
+	v->dst_port_be = *(uint16_t *)nla_data(tb_proto[CTA_PROTO_DST_PORT]);
 	return 0;
 }
 
@@ -219,9 +228,7 @@ int is_nf_dsnat(struct nlmsghdr *hdr)
 int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 {
 	struct nlattr *tb[CTA_MAX + 1];
-	uint8_t family;
-	const void *rsrc_ip, *rdst_ip;
-	uint16_t rsrc_port, rdst_port;
+	struct ct_tuple_view reply;
 	struct nlmsghdr *new_hdr;
 	uint32_t old_len;
 	uint8_t appended[4096]; /* max 2 * CTA_NAT_* nestings, always fits */
@@ -238,14 +245,14 @@ int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 
 	status = ntohl(nla_get_u32(tb[CTA_STATUS]));
 
-	if (parse_tuple_attrs(tb[CTA_TUPLE_REPLY], &family, &rsrc_ip, &rsrc_port, &rdst_ip, &rdst_port) < 0)
+	if (decode_ct_tuple(tb[CTA_TUPLE_REPLY], &reply) < 0)
 		return 1;
 
 	if (status & IPS_DST_NAT) {
 		/* orig.dst was rewritten; reply.src reveals the rewrite target */
 		n = nat_nested_from_tuple_ip_port(appended + appended_len,
 				sizeof(appended) - appended_len, CTA_NAT_DST,
-				family, rsrc_ip, rsrc_port);
+				reply.family, reply.src_ip, reply.src_port_be);
 		if (n < 0)
 			return 1;
 		appended_len += n;
@@ -254,7 +261,7 @@ int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 		/* orig.src was rewritten; reply.dst reveals the rewrite target */
 		n = nat_nested_from_tuple_ip_port(appended + appended_len,
 				sizeof(appended) - appended_len, CTA_NAT_SRC,
-				family, rdst_ip, rdst_port);
+				reply.family, reply.dst_ip, reply.dst_port_be);
 		if (n < 0)
 			return 1;
 		appended_len += n;
@@ -300,49 +307,26 @@ int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 ///
 
 /*
- * Decode a single conntrack tuple (CTA_TUPLE_ORIG or CTA_TUPLE_REPLY) into printable form.
- * src_ip/dst_ip get an INET6_ADDRSTRLEN-sized buffer; ports are returned in host order.
- * Returns 0 on success, -1 if the tuple is incomplete or malformed.
+ * Decode a tuple into printable form for logging. Family is inferred from the
+ * tuple itself (caller can cross-check against nfgen_family). Ports are
+ * returned in host order. Returns 0 on success, -1 on malformed input.
  */
-static int format_ct_tuple(struct nlattr *tuple, uint8_t family,
+static int format_ct_tuple(struct nlattr *tuple,
 			   char *src_ip, char *dst_ip, size_t ip_len,
 			   uint8_t *l4proto, uint16_t *src_port,
 			   uint16_t *dst_port)
 {
-	struct nlattr *tb[CTA_TUPLE_MAX + 1];
-	struct nlattr *tb_ip[CTA_IP_MAX + 1];
-	struct nlattr *tb_proto[CTA_PROTO_MAX + 1];
-	const void *src_raw, *dst_raw;
+	struct ct_tuple_view v;
 
-	if (nla_parse_nested(tb, CTA_TUPLE_MAX, tuple, NULL) < 0)
+	if (decode_ct_tuple(tuple, &v) < 0)
 		return -1;
-	if (!tb[CTA_TUPLE_IP] || !tb[CTA_TUPLE_PROTO])
-		return -1;
-	if (nla_parse_nested(tb_ip, CTA_IP_MAX, tb[CTA_TUPLE_IP], NULL) < 0)
-		return -1;
-	if (nla_parse_nested(tb_proto, CTA_PROTO_MAX, tb[CTA_TUPLE_PROTO], NULL) < 0)
+	if (!inet_ntop(v.family, v.src_ip, src_ip, ip_len) ||
+	    !inet_ntop(v.family, v.dst_ip, dst_ip, ip_len))
 		return -1;
 
-	if (family == AF_INET) {
-		if (!tb_ip[CTA_IP_V4_SRC] || !tb_ip[CTA_IP_V4_DST])
-			return -1;
-		src_raw = nla_data(tb_ip[CTA_IP_V4_SRC]);
-		dst_raw = nla_data(tb_ip[CTA_IP_V4_DST]);
-	} else {
-		if (!tb_ip[CTA_IP_V6_SRC] || !tb_ip[CTA_IP_V6_DST])
-			return -1;
-		src_raw = nla_data(tb_ip[CTA_IP_V6_SRC]);
-		dst_raw = nla_data(tb_ip[CTA_IP_V6_DST]);
-	}
-
-	if (!inet_ntop(family, src_raw, src_ip, ip_len))
-		return -1;
-	if (!inet_ntop(family, dst_raw, dst_ip, ip_len))
-		return -1;
-
-	*l4proto = tb_proto[CTA_PROTO_NUM] ? nla_get_u8(tb_proto[CTA_PROTO_NUM]) : 0;
-	*src_port = tb_proto[CTA_PROTO_SRC_PORT] ? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_SRC_PORT])) : 0;
-	*dst_port = tb_proto[CTA_PROTO_DST_PORT] ? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_DST_PORT])) : 0;
+	*l4proto = v.l4proto;
+	*src_port = ntohs(v.src_port_be);
+	*dst_port = ntohs(v.dst_port_be);
 	return 0;
 }
 
@@ -367,9 +351,9 @@ void log_ct_entry(struct nlmsghdr *nlh)
 	if (tb[CTA_STATUS])
 		status = ntohl(nla_get_u32(tb[CTA_STATUS]));
 	if (tb[CTA_TUPLE_ORIG])
-		format_ct_tuple(tb[CTA_TUPLE_ORIG], nfm->nfgen_family, o_src, o_dst, sizeof(o_src), &o_proto, &o_sp, &o_dp);
+		format_ct_tuple(tb[CTA_TUPLE_ORIG], o_src, o_dst, sizeof(o_src), &o_proto, &o_sp, &o_dp);
 	if (tb[CTA_TUPLE_REPLY])
-		format_ct_tuple(tb[CTA_TUPLE_REPLY], nfm->nfgen_family, r_src, r_dst, sizeof(r_src), &r_proto, &r_sp, &r_dp);
+		format_ct_tuple(tb[CTA_TUPLE_REPLY], r_src, r_dst, sizeof(r_src), &r_proto, &r_sp, &r_dp);
 
 	pr_err("CT restore: %s proto=%u orig=%s:%u->%s:%u reply=%s:%u->%s:%u "
 	       "status=0x%08x%s%s%s%s%s%s%s\n",

--- a/criu/net-clm-conntrack.c
+++ b/criu/net-clm-conntrack.c
@@ -10,25 +10,29 @@
 #include "net-clm-conntrack.h"
 
 /*
- * The kernel's conntrack dump path (IPCTNL_MSG_CT_GET, NLM_F_DUMP) never emits
- * CTA_NAT_SRC / CTA_NAT_DST — those attributes are input-only, consumed by
- * IPCTNL_MSG_CT_NEW to bind a NAT extension to the entry. And CTA_STATUS bits
- * IPS_{SRC,DST}_NAT{,_DONE} are in IPS_UNCHANGEABLE_MASK in the kernel, so
- * ctnetlink_change_status() silently strips them on replay.
+ * Modern Linux kernel source code includes a 'specs/conntrack.yaml' with a schema of conntrack netlink messages.
+ * E.g. https://docs.kernel.org/_sources/netlink/specs/conntrack.yaml.txt .
+ */
+
+/*
+ * The kernel's conntrack dump path (IPCTNL_MSG_CT_GET, NLM_F_DUMP) never emits CTA_NAT_SRC / CTA_NAT_DST.
+ * Those attributes are input-only, consumed by IPCTNL_MSG_CT_NEW to bind a NAT extension to the entry.
+ * CTA_STATUS bits IPS_{SRC,DST}_NAT{,_DONE} are in IPS_UNCHANGEABLE_MASK in the kernel,
+ * so ctnetlink_change_status() strips them on replay.
  *
- * Result: round-tripping conntrack via dump→restore loses NAT bindings — the
- * flow is re-tracked but reply packets are no longer reverse-translated,
- * breaking e.g. Istio's REDIRECT-based sidecar interception across migration.
+ * Result: round-tripping conntrack via dump→restore loses NAT bindings — the flow is re-tracked
+ * but reply packets are not reverse-translated, breaking Istio's REDIRECT-based sidecar interception across migration.
  *
  * The NAT rewrite is recoverable from the two tuples the kernel does emit:
  *   reply.src <=> post-DNAT form of orig.dst   (when IPS_DST_NAT set)
  *   reply.dst <=> post-SNAT form of orig.src   (when IPS_SRC_NAT set)
  *
- * Synthesize CTA_NAT_SRC/CTA_NAT_DST from this delta at dump time so that the
- * on-disk message, when replayed through IPCTNL_MSG_CT_NEW, triggers the
- * kernel's ctnetlink_setup_nat() and re-binds NAT (which in turn sets the
- * status bits naturally).
+ * Synthesize CTA_NAT_SRC/CTA_NAT_DST from this delta at dump time so that the on-disk message,
+ * when replayed through IPCTNL_MSG_CT_NEW,
+ * triggers the kernel's ctnetlink_setup_nat() and re-binds NAT (which sets the status bits naturally).
  */
+
+
 static int nat_nested_from_tuple_ip_port(uint8_t *out, int max, int nest_type,
 					  uint8_t family, const void *ip, uint16_t port_be)
 {
@@ -72,6 +76,7 @@ static int nat_nested_from_tuple_ip_port(uint8_t *out, int max, int nest_type,
 	proto_attr->nla_type = CTA_NAT_PROTO | NLA_F_NESTED;
 	p += NLA_HDRLEN;
 
+    // CTA_NAT_PROTO -> CTA_PROTONAT_PORT_MIN
 	len = NLA_HDRLEN + sizeof(uint16_t);
 	if ((p - out) + 2 * NLA_ALIGN(len) > max)
 		return -1;
@@ -82,6 +87,7 @@ static int nat_nested_from_tuple_ip_port(uint8_t *out, int max, int nest_type,
 	memset(p + NLA_HDRLEN + sizeof(uint16_t), 0, NLA_ALIGN(len) - len);
 	p += NLA_ALIGN(len);
 
+    // CTA_NAT_PROTO -> CTA_PROTONAT_PORT_MAX
 	ip_attr = (struct nlattr *)p;
 	ip_attr->nla_type = CTA_PROTONAT_PORT_MAX;
 	ip_attr->nla_len = len;
@@ -96,10 +102,10 @@ static int nat_nested_from_tuple_ip_port(uint8_t *out, int max, int nest_type,
 }
 
 /*
- * Parse the reply tuple to pull out (family, src_ip, src_port, dst_ip, dst_port)
- * in the on-wire form. Returns 0 on success, -1 on malformed input.
+ * Parse a 'tuple-attrs' to pull out (family, src_ip, src_port, dst_ip, dst_port) in the on-wire form.
+ * Returns 0 on success, -1 on malformed input.
  */
-static int parse_reply_tuple(const struct nlattr *tuple_reply, uint8_t *family,
+static int parse_tuple_attrs(const struct nlattr *tuple_reply, uint8_t *family,
 			     const void **src_ip, uint16_t *src_port,
 			     const void **dst_ip, uint16_t *dst_port)
 {
@@ -177,10 +183,8 @@ static int invert_orig_into_reply(struct nlattr *orig_tuple, struct nlattr *repl
 	if (!o_pr[CTA_PROTO_SRC_PORT] || !o_pr[CTA_PROTO_DST_PORT] ||
 	    !r_pr[CTA_PROTO_SRC_PORT] || !r_pr[CTA_PROTO_DST_PORT])
 		return -1;
-	memcpy(nla_data(r_pr[CTA_PROTO_SRC_PORT]),
-	       nla_data(o_pr[CTA_PROTO_DST_PORT]), sizeof(uint16_t));
-	memcpy(nla_data(r_pr[CTA_PROTO_DST_PORT]),
-	       nla_data(o_pr[CTA_PROTO_SRC_PORT]), sizeof(uint16_t));
+	memcpy(nla_data(r_pr[CTA_PROTO_SRC_PORT]), nla_data(o_pr[CTA_PROTO_DST_PORT]), sizeof(uint16_t));
+	memcpy(nla_data(r_pr[CTA_PROTO_DST_PORT]), nla_data(o_pr[CTA_PROTO_SRC_PORT]), sizeof(uint16_t));
 	return 0;
 }
 
@@ -234,7 +238,7 @@ int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 
 	status = ntohl(nla_get_u32(tb[CTA_STATUS]));
 
-	if (parse_reply_tuple(tb[CTA_TUPLE_REPLY], &family, &rsrc_ip, &rsrc_port, &rdst_ip, &rdst_port) < 0)
+	if (parse_tuple_attrs(tb[CTA_TUPLE_REPLY], &family, &rsrc_ip, &rsrc_port, &rdst_ip, &rdst_port) < 0)
 		return 1;
 
 	if (status & IPS_DST_NAT) {
@@ -293,11 +297,12 @@ int dump_one_nf_dsnat(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 	return ret;
 }
 
+///
+
 /*
- * Decode a single conntrack tuple (CTA_TUPLE_ORIG or CTA_TUPLE_REPLY) into
- * printable form. src_ip/dst_ip get an INET6_ADDRSTRLEN-sized buffer; ports
- * are returned in host order. Returns 0 on success, -1 if the tuple is
- * incomplete or malformed.
+ * Decode a single conntrack tuple (CTA_TUPLE_ORIG or CTA_TUPLE_REPLY) into printable form.
+ * src_ip/dst_ip get an INET6_ADDRSTRLEN-sized buffer; ports are returned in host order.
+ * Returns 0 on success, -1 if the tuple is incomplete or malformed.
  */
 static int format_ct_tuple(struct nlattr *tuple, uint8_t family,
 			   char *src_ip, char *dst_ip, size_t ip_len,
@@ -308,7 +313,6 @@ static int format_ct_tuple(struct nlattr *tuple, uint8_t family,
 	struct nlattr *tb_ip[CTA_IP_MAX + 1];
 	struct nlattr *tb_proto[CTA_PROTO_MAX + 1];
 	const void *src_raw, *dst_raw;
-	int af = (family == AF_INET) ? AF_INET : AF_INET6;
 
 	if (nla_parse_nested(tb, CTA_TUPLE_MAX, tuple, NULL) < 0)
 		return -1;
@@ -331,16 +335,14 @@ static int format_ct_tuple(struct nlattr *tuple, uint8_t family,
 		dst_raw = nla_data(tb_ip[CTA_IP_V6_DST]);
 	}
 
-	if (!inet_ntop(af, src_raw, src_ip, ip_len))
+	if (!inet_ntop(family, src_raw, src_ip, ip_len))
 		return -1;
-	if (!inet_ntop(af, dst_raw, dst_ip, ip_len))
+	if (!inet_ntop(family, dst_raw, dst_ip, ip_len))
 		return -1;
 
 	*l4proto = tb_proto[CTA_PROTO_NUM] ? nla_get_u8(tb_proto[CTA_PROTO_NUM]) : 0;
-	*src_port = tb_proto[CTA_PROTO_SRC_PORT]
-				? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_SRC_PORT])) : 0;
-	*dst_port = tb_proto[CTA_PROTO_DST_PORT]
-				? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_DST_PORT])) : 0;
+	*src_port = tb_proto[CTA_PROTO_SRC_PORT] ? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_SRC_PORT])) : 0;
+	*dst_port = tb_proto[CTA_PROTO_DST_PORT] ? ntohs(*(uint16_t *)nla_data(tb_proto[CTA_PROTO_DST_PORT])) : 0;
 	return 0;
 }
 
@@ -365,13 +367,9 @@ void log_ct_entry(struct nlmsghdr *nlh)
 	if (tb[CTA_STATUS])
 		status = ntohl(nla_get_u32(tb[CTA_STATUS]));
 	if (tb[CTA_TUPLE_ORIG])
-		format_ct_tuple(tb[CTA_TUPLE_ORIG], nfm->nfgen_family,
-				o_src, o_dst, sizeof(o_src),
-				&o_proto, &o_sp, &o_dp);
+		format_ct_tuple(tb[CTA_TUPLE_ORIG], nfm->nfgen_family, o_src, o_dst, sizeof(o_src), &o_proto, &o_sp, &o_dp);
 	if (tb[CTA_TUPLE_REPLY])
-		format_ct_tuple(tb[CTA_TUPLE_REPLY], nfm->nfgen_family,
-				r_src, r_dst, sizeof(r_src),
-				&r_proto, &r_sp, &r_dp);
+		format_ct_tuple(tb[CTA_TUPLE_REPLY], nfm->nfgen_family, r_src, r_dst, sizeof(r_src), &r_proto, &r_sp, &r_dp);
 
 	pr_err("CT restore: %s proto=%u orig=%s:%u->%s:%u reply=%s:%u->%s:%u "
 	       "status=0x%08x%s%s%s%s%s%s%s\n",

--- a/criu/net.c
+++ b/criu/net.c
@@ -1,10 +1,12 @@
 #include <unistd.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/netfilter/nfnetlink.h>
 #include <linux/netfilter/nfnetlink_conntrack.h>
 #include <linux/netfilter/nf_conntrack_tcp.h>
+#include <linux/netfilter/nf_conntrack_common.h>
 #include <string.h>
 #include <net/if_arp.h>
 #include <sys/wait.h>
@@ -30,6 +32,7 @@
 #include "imgset.h"
 #include "namespaces.h"
 #include "net.h"
+#include "net-clm-conntrack.h"
 #include "libnetlink.h"
 #include "cr_options.h"
 #include "sk-inet.h"
@@ -941,18 +944,30 @@ static int dump_one_link(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 	return ret;
 }
 
+
 static int dump_one_nf(struct nlmsghdr *hdr, struct ns_id *ns, void *arg)
 {
 	struct cr_img *img = arg;
+	int ret;
 
 	if (lazy_image(img) && open_image_lazy(img))
 		return -1;
+
+	if (is_nf_dsnat(hdr)) {
+	    ret = dump_one_nf_dsnat(hdr, ns, arg);
+        if (ret < 0)
+            return -1;
+        else if (ret == 0)
+            return 0; /* skip this entry, already handled in dump_one_nf_dsnat */
+        // else ret == 1: not a DSNAT entry, fall back to normal dumping
+    }
 
 	if (write_img_buf(img, hdr, hdr->nlmsg_len))
 		return -1;
 
 	return 0;
 }
+
 
 static int ct_restore_callback(struct nlmsghdr *nlh)
 {
@@ -1055,8 +1070,13 @@ static int restore_nf_ct(int pid, int type)
 
 		nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE;
 		ret = do_rtnl_req(sk, nlh, nlh->nlmsg_len, NULL, NULL, NULL, NULL);
-		if (ret)
-			goto out;
+		if (ret) {
+			pr_err("nf_ct restore failed (ret=%d)\n", ret);
+            if (type == CR_FD_NETNF_CT) {
+                log_ct_entry(nlh);
+            }
+            goto out;
+		}
 	}
 
 	exit_code = 0;
@@ -1087,7 +1107,7 @@ static int dump_nf_ct(struct cr_imgset *fds, int type)
 
 	memset(&req, 0, sizeof(req));
 	req.nlh.nlmsg_len = sizeof(req);
-	req.nlh.nlmsg_type = (NFNL_SUBSYS_CTNETLINK << 8);
+	req.nlh.nlmsg_type = (type == CR_FD_NETNF_EXP ? NFNL_SUBSYS_CTNETLINK_EXP : NFNL_SUBSYS_CTNETLINK) << 8;
 
 	if (type == CR_FD_NETNF_CT)
 		req.nlh.nlmsg_type |= IPCTNL_MSG_CT_GET;

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -98,6 +98,7 @@ TST_NOFILE	:=				\
 		socket-tcp-local		\
 		socket-tcp-reuseport		\
 		socket-tcp-ipt-nfconntrack	\
+		socket-tcp-ipt-redirect-conntrack	\
 		socket-tcp-nft-nfconntrack	\
 		socket-tcp6-local		\
 		socket-tcp4v6-local		\

--- a/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c
+++ b/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c
@@ -16,29 +16,29 @@ const char *test_author = "Dmytro Bainak <dbaynak@protonmail.com>";
 #define BUF_SIZE   4096
 #define REDIR_PORT 12345
 
-int read_write_data(int fd, unsigned char *buf, size_t len, uint32_t* crc) {
+int read_write_data(int fd, unsigned char *buf, size_t len, uint32_t* crc, char* tag) {
     if (read_data(fd, buf, len)) {
-        pr_perror("read less than have to (pre)");
+        pr_perror("read less than have to (%s)", tag);
         return 1;
     }
     if (datachk(buf, len, crc))
         return 2;
     datagen(buf, BUF_SIZE, crc);
     if (write_data(fd, buf, BUF_SIZE)) {
-        pr_perror("can't write (pre)");
+        pr_perror("can't write (%s)", tag);
         return 1;
     }
     return 0;
 }
 
-int write_read_data(int fd, unsigned char *buf, size_t len, uint32_t* crc) {
+int write_read_data(int fd, unsigned char *buf, size_t len, uint32_t* crc, char* tag) {
     datagen(buf, len, crc);
     if (write_data(fd, buf, len)) {
-        pr_perror("can't write (pre)");
+        pr_perror("can't write (%s)", tag);
         return 1;
     }
     if (read_data(fd, buf, len)) {
-        pr_perror("read less than have to (pre)");
+        pr_perror("read less than have to (%s)", tag);
         return 1;
     }
     if (datachk(buf, len, crc))
@@ -103,14 +103,14 @@ int main(int argc, char **argv)
 			return 1;
 
         // Pre-migration round-trip: server -> client, client -> server.
-        ret = read_write_data(fd, buf, BUF_SIZE, &crc);
+        ret = read_write_data(fd, buf, BUF_SIZE, &crc, "pre");
         if (ret) {
             pr_err("pre-migration data exchange failed: %d\n", ret);
             return 1;
         }
 
         // Post-migration round-trip: server -> client, client -> server.
-        ret = read_write_data(fd, buf, BUF_SIZE, &crc);
+        ret = read_write_data(fd, buf, BUF_SIZE, &crc, "post");
         if (ret) {
             pr_err("post-migration data exchange failed: %d\n", ret);
             return 1;
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-    ret = write_read_data(fd, buf, BUF_SIZE, &crc);
+    ret = write_read_data(fd, buf, BUF_SIZE, &crc, "pre");
 	if (ret) {
         pr_err("pre-migration data exchange failed: %d\n", ret);
         return 1;
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
 	test_daemon();
 	test_waitsig();
 
-    ret = write_read_data(fd, buf, BUF_SIZE, &crc);
+    ret = write_read_data(fd, buf, BUF_SIZE, &crc, "post");
     if (ret) {
         pr_err("post-migration data exchange failed: %d\n", ret);
         return 1;

--- a/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c
+++ b/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c
@@ -1,0 +1,140 @@
+#include "zdtmtst.h"
+
+const char *test_doc = "Check TCP DNAT (iptables REDIRECT) conntrack survives C/R\n";
+const char *test_author = "Dmytro Bainak <dbaynak@protonmail.com>";
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sched.h>
+#include <sys/types.h>
+#include <netinet/tcp.h>
+
+#define BUF_SIZE   4096
+#define REDIR_PORT 12345
+
+int read_write_data(int fd, unsigned char *buf, size_t len, uint32_t* crc) {
+    if (read_data(fd, buf, len)) {
+        pr_perror("read less than have to (pre)");
+        return 1;
+    }
+    if (datachk(buf, len, crc))
+        return 2;
+    datagen(buf, BUF_SIZE, crc);
+    if (write_data(fd, buf, BUF_SIZE)) {
+        pr_perror("can't write (pre)");
+        return 1;
+    }
+    return 0;
+}
+
+int write_read_data(int fd, unsigned char *buf, size_t len, uint32_t* crc) {
+    datagen(buf, len, crc);
+    if (write_data(fd, buf, len)) {
+        pr_perror("can't write (pre)");
+        return 1;
+    }
+    if (read_data(fd, buf, len)) {
+        pr_perror("read less than have to (pre)");
+        return 1;
+    }
+    if (datachk(buf, len, crc))
+        return 2;
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+	unsigned char buf[BUF_SIZE];
+	int fd, fd_s;
+	pid_t extpid;
+	uint32_t crc;
+	int real_port = 8880;
+	char rule[256];
+
+	if (unshare(CLONE_NEWNET)) {
+		pr_perror("unshare");
+		return 1;
+	}
+	if (system("ip link set up dev lo"))
+		return 1;
+
+	/*
+	 * Bring the server up first so we know the real port to point the
+	 * REDIRECT rule at. The connect()ing peer never sees this port -- it
+	 * targets REDIR_PORT and the kernel DNATs.
+	 */
+	if ((fd_s = tcp_init_server(AF_INET, &real_port)) < 0) {
+		pr_err("initializing server failed\n");
+		return 1;
+	}
+
+	snprintf(rule, sizeof(rule),
+		 "iptables -t nat -w -A OUTPUT -p tcp --dport %d "
+		 "-j REDIRECT --to-ports %d", REDIR_PORT, real_port);
+	if (system(rule))
+		return 1;
+
+	/*
+	 * Force every packet through conntrack so the kernel populates an
+	 * entry with IPS_DST_NAT set (and CTA_NAT_DST on dump). Without the
+	 * DROP fallback, replies could bypass tracking on a hot path.
+	 */
+	if (system("iptables -w -A INPUT -i lo -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT"))
+		return 1;
+	if (system("iptables -w -A INPUT -j DROP"))
+		return 1;
+
+	test_init(argc, argv);
+
+	extpid = fork();
+	if (extpid < 0) {
+		pr_perror("fork() failed");
+		return 1;
+	} else if (extpid == 0) {
+		close(fd_s);
+
+		fd = tcp_init_client(AF_INET, "127.0.0.1", REDIR_PORT);
+		if (fd < 0)
+			return 1;
+
+        // Pre-migration round-trip: server -> client, client -> server.
+        if (int ret = read_write_data(fd, buf, BUF_SIZE, &crc); ret) {
+            pr_err("pre-migration data exchange failed: %d\n", ret);
+            return 1;
+        }
+
+        // Post-migration round-trip: server -> client, client -> server.
+        if (int ret = read_write_data(fd, buf, BUF_SIZE, &crc); ret) {
+            pr_err("post-migration data exchange failed: %d\n", ret);
+            return 1;
+        }
+
+		return 0;
+	}
+
+	fd = tcp_accept_server(fd_s);
+	if (fd < 0) {
+		pr_err("can't accept client connection\n");
+		return 1;
+	}
+
+	if (int ret = write_read_data(fd, buf, BUF_SIZE, &crc); ret) {
+        pr_err("pre-migration data exchange failed: %d\n", ret);
+        return 1;
+    }
+
+	test_daemon();
+	test_waitsig();
+
+    if (int ret = write_read_data(fd, buf, BUF_SIZE, &crc); ret) {
+        pr_err("post-migration data exchange failed: %d\n", ret);
+        return 1;
+    }
+
+	pass();
+	return 0;
+}

--- a/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c
+++ b/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c
@@ -51,9 +51,10 @@ int main(int argc, char **argv)
 	unsigned char buf[BUF_SIZE];
 	int fd, fd_s;
 	pid_t extpid;
-	uint32_t crc;
+	uint32_t crc = 0;
 	int real_port = 8880;
 	char rule[256];
+    int ret = 0;
 
 	if (unshare(CLONE_NEWNET)) {
 		pr_perror("unshare");
@@ -102,13 +103,15 @@ int main(int argc, char **argv)
 			return 1;
 
         // Pre-migration round-trip: server -> client, client -> server.
-        if (int ret = read_write_data(fd, buf, BUF_SIZE, &crc); ret) {
+        ret = read_write_data(fd, buf, BUF_SIZE, &crc);
+        if (ret) {
             pr_err("pre-migration data exchange failed: %d\n", ret);
             return 1;
         }
 
         // Post-migration round-trip: server -> client, client -> server.
-        if (int ret = read_write_data(fd, buf, BUF_SIZE, &crc); ret) {
+        ret = read_write_data(fd, buf, BUF_SIZE, &crc);
+        if (ret) {
             pr_err("post-migration data exchange failed: %d\n", ret);
             return 1;
         }
@@ -122,7 +125,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if (int ret = write_read_data(fd, buf, BUF_SIZE, &crc); ret) {
+    ret = write_read_data(fd, buf, BUF_SIZE, &crc);
+	if (ret) {
         pr_err("pre-migration data exchange failed: %d\n", ret);
         return 1;
     }
@@ -130,7 +134,8 @@ int main(int argc, char **argv)
 	test_daemon();
 	test_waitsig();
 
-    if (int ret = write_read_data(fd, buf, BUF_SIZE, &crc); ret) {
+    ret = write_read_data(fd, buf, BUF_SIZE, &crc);
+    if (ret) {
         pr_err("post-migration data exchange failed: %d\n", ret);
         return 1;
     }

--- a/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.desc
+++ b/test/zdtm/static/socket-tcp-ipt-redirect-conntrack.desc
@@ -1,0 +1,6 @@
+{
+    'feature': 'has_ipt_legacy',
+    'flavor': 'h',
+    'opts': '--tcp-established',
+    'flags': 'suid'
+}


### PR DESCRIPTION
CRIU original implementation just takes the conntrack entries from the network namespace and restores them as-is on the destination side.

The Linux kernel ignores IPS_{SRC,DST}_NAT flags from CTA_STATUS 'field' for freshly created conntrack entries.

And, the kernel will setup NAT if relevant attributes (in the 'table of attributes' as in `tb` in the code) -- CTA_NAT_SRC or CTA_NAT_DST -- are provided with the conntrack entry on creation. Those attributes **are not returned by the kernel/netlink**.

It means that connections where conntrack entries are actually needed to 'route' packets of a connection (eg when iptables REDIRECT is used), the restored conntrack entries are actually misleading for the kernel. The iptables REDIRECT is not applied, packets are lost, connections **silently** break (no TCP RST, they are just stuck until timeouts).

The PR just 'detects' the D/SNAT conntrack entries from tuple_orig/tuple_reply 'mismatch', and 'synthesizes' relevant CTA_NAT_SRC or CTA_NAT_DST for the dumped entries, allowing the restored conntrack entry to be 'correct'.
It also 'resets the reply tuple to invert(orig) so the kernel's NAT setup branch isn't short-circuited', but I (the human who wrote the above) is yet to figure out why exactly this is needed or what it really means.

---
### Kimchi Summary
### What changed
Preserves NAT-bound conntrack entries (SNAT/DNAT) across checkpoint/restore by synthesizing missing `CTA_NAT_SRC`/`CTA_NAT_DST` netlink attributes from tuple deltas and rewriting reply tuples during dump. Also fixes a netlink subsystem mismatch when dumping conntrack expectations and adds a ZDTM test for iptables `REDIRECT`.

### Why
The kernel conntrack dump path never emits `CTA_NAT_*` attributes, so restoring a dumped entry loses NAT bindings. This causes reply packets to stop being reverse-translated, breaking Istio-style `REDIRECT`-based sidecar traffic interception after migration.

### Key changes
- `criu/net-clm-conntrack.c` (new): Implements `dump_one_nf_dsnat` to synthesize `CTA_NAT_SRC`/`CTA_NAT_DST` from the orig/reply tuple delta; adds `invert_orig_into_reply` to swap the reply tuple’s src/dst IP and ports so the kernel’s `nf_nat_setup_info()` re-binds NAT on restore. Introduces `is_nf_dsnat` to detect NAT entries and `log_ct_entry` for structured debug logging.
- `criu/include/net-clm-conntrack.h` (new): Declares the new conntrack NAT helpers.
- `criu/net.c`: Integrates `is_nf_dsnat`/`dump_one_nf_dsnat` into `dump_one_nf` so NAT entries are rewritten before image write; adds `log_ct_entry` call on restore failure in `restore_nf_ct`; fixes `dump_nf_ct` to use `NFNL_SUBSYS_CTNETLINK_EXP` for expectation dumps and `NFNL_SUBSYS_CTNETLINK` for conntrack dumps.
- `criu/Makefile.crtools`: Links the new `net-clm-conntrack.o` object.
- `test/zdtm/static/socket-tcp-ipt-redirect-conntrack.c` (new) and `.desc` (new): Adds a ZDTM test that validates a TCP connection through an iptables `REDIRECT` rule survives checkpoint/restore with `--tcp-established`.

### Impact
- The `dump_nf_ct` subsystem fix corrects expectation dumping, which previously always used `NFNL_SUBSYS_CTNETLINK`; downstream consumers of expectation images will now see the correct message types.
- Changes are additive for non-NAT conntrack entries, which continue through the existing dump path unchanged.