### PR TITLE
fix: increase pipe limit

### DIFF
--- a/criu/include/pipes.h
+++ b/criu/include/pipes.h
@@ -13,7 +13,7 @@ static inline u32 pipe_id(const struct fd_parms *p)
 	return p->stat.st_ino;
 }
 
-#define NR_PIPES_WITH_DATA 1024
+#define NR_PIPES_WITH_DATA 2048
 
 struct pipe_data_dump {
 	int img_type;


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Increases the limit on pipes carrying data that CRIU can track during checkpoint and restore operations from `1024` to `2048`.

### Key changes
- `criu/include/pipes.h`: Raised `NR_PIPES_WITH_DATA` from `1024` to `2048`.