### PR TITLE
fix: link remap restore on tmpfs

### DIFF
--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1412,7 +1412,7 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms, 
 
 		if (errno == ENOENT) {
 			link_strip_deleted(link);
-			/*
+			/* CAST AI
 			 * On tmpfs (e.g. /dev/shm), link_remap.N is created on
 			 * the source node's in-memory tmpfs and is never included
 			 * in the checkpoint.  The destination node always starts

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1412,17 +1412,27 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms, 
 
 		if (errno == ENOENT) {
 			link_strip_deleted(link);
-			/* CAST AI
-			 * On tmpfs (e.g. /dev/shm), link_remap.N is created on
-			 * the source node's in-memory tmpfs and is never included
-			 * in the checkpoint.  The destination node always starts
-			 * with an empty tmpfs, so rfi_remap() fails with ENOENT
-			 * on restore.  Fall back to dump_ghost_remap() which
-			 * embeds the file content in the CRIU image and
-			 * reconstructs it correctly on any node.
+			/*
+			 * On external tmpfs mounts (e.g. /dev/shm provided by
+			 * the container runtime), link_remap.N is created on
+			 * the source node's in-memory tmpfs but is not included
+			 * in the checkpoint since CRIU does not dump external
+			 * mount contents.  The destination node gets a fresh
+			 * empty tmpfs, so rfi_remap() fails with ENOENT on
+			 * restore.  Fall back to dump_ghost_remap() which
+			 * embeds the file content in the image.
+			 *
+			 * For CRIU-managed tmpfs mounts (dumped via tar),
+			 * link_remap.N is preserved in the archive, so the
+			 * normal dump_linked_remap() path works correctly.
 			 */
-			if (parms->fs_type == TMPFS_MAGIC)
-				return dump_ghost_remap(rpath + 1, ost, lfd, id, nsid);
+			if (parms->fs_type == TMPFS_MAGIC) {
+				struct mount_info *mi;
+
+				mi = lookup_mnt_id(parms->mnt_id);
+				if (mi && (mi->external || mnt_is_external_bind(mi)))
+					return dump_ghost_remap(rpath + 1, ost, lfd, id, nsid);
+			}
 			ret = dump_linked_remap(rpath + 1, plen - 1, parms, lfd, id, nsid, &fallback);
 			if (ret < 0 && fallback) {
 				/* fallback is true only if following conditions are true:

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1412,6 +1412,17 @@ static int check_path_remap(struct fd_link *link, const struct fd_parms *parms, 
 
 		if (errno == ENOENT) {
 			link_strip_deleted(link);
+			/*
+			 * On tmpfs (e.g. /dev/shm), link_remap.N is created on
+			 * the source node's in-memory tmpfs and is never included
+			 * in the checkpoint.  The destination node always starts
+			 * with an empty tmpfs, so rfi_remap() fails with ENOENT
+			 * on restore.  Fall back to dump_ghost_remap() which
+			 * embeds the file content in the CRIU image and
+			 * reconstructs it correctly on any node.
+			 */
+			if (parms->fs_type == TMPFS_MAGIC)
+				return dump_ghost_remap(rpath + 1, ost, lfd, id, nsid);
 			ret = dump_linked_remap(rpath + 1, plen - 1, parms, lfd, id, nsid, &fallback);
 			if (ret < 0 && fallback) {
 				/* fallback is true only if following conditions are true:

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -294,6 +294,7 @@ TST_NOFILE	:=				\
 		sigtrap01			\
 		change_mnt_context		\
 		fd_offset			\
+		tmpfs_link_remap		\
 #		jobctl00			\
 
 PKG_CONFIG ?= pkg-config
@@ -438,7 +439,6 @@ TST_DIR		=				\
 		mntns_remap			\
 		mntns_open			\
 		mntns_link_remap		\
-		tmpfs_link_remap		\
 		mntns_ghost			\
 		mntns_ghost01			\
 		mntns_ro_root			\

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -294,7 +294,6 @@ TST_NOFILE	:=				\
 		sigtrap01			\
 		change_mnt_context		\
 		fd_offset			\
-		tmpfs_link_remap		\
 #		jobctl00			\
 
 PKG_CONFIG ?= pkg-config
@@ -439,6 +438,7 @@ TST_DIR		=				\
 		mntns_remap			\
 		mntns_open			\
 		mntns_link_remap		\
+		tmpfs_link_remap		\
 		mntns_ghost			\
 		mntns_ghost01			\
 		mntns_ro_root			\

--- a/test/zdtm/static/Makefile
+++ b/test/zdtm/static/Makefile
@@ -438,6 +438,7 @@ TST_DIR		=				\
 		mntns_remap			\
 		mntns_open			\
 		mntns_link_remap		\
+		tmpfs_link_remap		\
 		mntns_ghost			\
 		mntns_ghost01			\
 		mntns_ro_root			\

--- a/test/zdtm/static/tmpfs_link_remap.c
+++ b/test/zdtm/static/tmpfs_link_remap.c
@@ -1,0 +1,132 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "zdtmtst.h"
+
+const char *test_doc	= "Check that a tmpfs file with st_nlink>=1 but "
+			  "mapped-path ENOENT (POSIX semaphore pattern) "
+			  "is correctly checkpointed and restored";
+const char *test_author = "Filipe Augusto Lima de Souza <filipe@cast.ai>";
+
+/*
+ * Reproduces the state created by Python multiprocessing on Linux (fork
+ * context): sem_open() creates /dev/shm/sem.NAME (st_nlink=1), mmaps it
+ * internally, then sem_unlink() removes the name while another hard link
+ * keeps st_nlink=1.
+ *
+ * Without the fix, CRIU dump takes dump_linked_remap() (because st_nlink>=1
+ * and fstatat ENOENT), creates link_remap.N on the source /dev/shm tmpfs,
+ * but never stores the content.  On restore, link_remap.N does not exist on
+ * the destination tmpfs -> ENOENT -> "Can't open vma".
+ *
+ * With the fix, CRIU detects TMPFS_MAGIC and falls back to dump_ghost_remap()
+ * which embeds the content in the checkpoint image.
+ */
+
+#define SHM_DIR		"/dev/shm"
+#define SEM_NAME	SHM_DIR "/sem.zdtm-link-remap-test"
+#define SEM_ANCHOR	SHM_DIR "/sem.zdtm-link-remap-anchor"
+#define SEM_SIZE	4096
+
+int main(int argc, char **argv)
+{
+	int fd;
+	void *map;
+	uint32_t crc_before, crc_after;
+	struct stat st;
+
+	test_init(argc, argv);
+
+	/* Clean up any leftovers. */
+	unlink(SEM_NAME);
+	unlink(SEM_ANCHOR);
+
+	/* Step 1: create the file on tmpfs. */
+	fd = open(SEM_NAME, O_RDWR | O_CREAT | O_EXCL, 0600);
+	if (fd < 0) {
+		pr_perror("open");
+		return 1;
+	}
+	if (ftruncate(fd, SEM_SIZE) < 0) {
+		pr_perror("ftruncate");
+		return 1;
+	}
+
+	/* Step 2: mmap it MAP_SHARED -- creates the file-backed VMA. */
+	map = mmap(NULL, SEM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (map == MAP_FAILED) {
+		pr_perror("mmap");
+		return 1;
+	}
+
+	/* Write known data and compute CRC before C/R. */
+	crc_before = ~0;
+	datagen(map, SEM_SIZE, &crc_before);
+
+	/*
+	 * Step 3: create a hard link so st_nlink becomes 2.
+	 * This keeps the inode alive after we remove the original name,
+	 * ensuring CRIU sees st_nlink=1 (not 0) and takes dump_linked_remap
+	 * instead of dump_ghost_remap -- which is the bug trigger.
+	 */
+	if (link(SEM_NAME, SEM_ANCHOR) < 0) {
+		pr_perror("link");
+		return 1;
+	}
+
+	/*
+	 * Step 4: unlink the mapped name.
+	 * st_nlink drops to 1 (anchor survives).
+	 * /proc/PID/maps now shows "sem.zdtm-link-remap-test (deleted)".
+	 * fstatat on that path returns ENOENT.
+	 * CRIU without fix: st_nlink=1 + ENOENT -> dump_linked_remap -> restore fails.
+	 * CRIU with fix:    TMPFS_MAGIC detected -> dump_ghost_remap -> restore works.
+	 */
+	if (unlink(SEM_NAME) < 0) {
+		pr_perror("unlink");
+		return 1;
+	}
+
+	/* Verify the trigger state: st_nlink=1, mapped path gone. */
+	if (fstat(fd, &st) < 0) {
+		pr_perror("fstat");
+		return 1;
+	}
+	if (st.st_nlink != 1) {
+		fail("Expected st_nlink=1, got %lu", (unsigned long)st.st_nlink);
+		return 1;
+	}
+
+	test_daemon();
+	test_waitsig();
+
+	/* After C/R: verify the mmap content is intact. */
+	crc_after = ~0;
+	if (datachk(map, SEM_SIZE, &crc_after)) {
+		fail("mmap content CRC mismatch after restore");
+		goto out;
+	}
+
+	/* Verify the fd is still usable. */
+	if (fstat(fd, &st) < 0) {
+		pr_perror("fstat after restore");
+		goto out;
+	}
+	if (st.st_size != SEM_SIZE) {
+		fail("fd size changed: expected %d got %lld",
+		     SEM_SIZE, (long long)st.st_size);
+		goto out;
+	}
+
+	pass();
+out:
+	munmap(map, SEM_SIZE);
+	close(fd);
+	unlink(SEM_ANCHOR); /* clean up anchor */
+	return 0;
+}

--- a/test/zdtm/static/tmpfs_link_remap.c
+++ b/test/zdtm/static/tmpfs_link_remap.c
@@ -3,8 +3,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/mount.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <linux/limits.h>
 
 #include "zdtmtst.h"
 
@@ -20,18 +22,18 @@ const char *test_author = "Filipe Augusto Lima de Souza <filipe@cast.ai>";
  * keeps st_nlink=1.
  *
  * Without the fix, CRIU dump takes dump_linked_remap() (because st_nlink>=1
- * and fstatat ENOENT), creates link_remap.N on the source /dev/shm tmpfs,
- * but never stores the content.  On restore, link_remap.N does not exist on
- * the destination tmpfs -> ENOENT -> "Can't open vma".
+ * and fstatat ENOENT), creates link_remap.N on the source tmpfs, but never
+ * stores the content.  On restore, link_remap.N does not exist on the
+ * destination tmpfs -> ENOENT -> "Can't open vma".
  *
  * With the fix, CRIU detects TMPFS_MAGIC and falls back to dump_ghost_remap()
  * which embeds the content in the checkpoint image.
  */
 
-#define SHM_DIR		"/dev/shm"
-#define SEM_NAME	SHM_DIR "/sem.zdtm-link-remap-test"
-#define SEM_ANCHOR	SHM_DIR "/sem.zdtm-link-remap-anchor"
-#define SEM_SIZE	4096
+#define FILE_SIZE	4096
+
+char *dirname;
+TEST_OPTION(dirname, string, "directory name", 1);
 
 int main(int argc, char **argv)
 {
@@ -39,34 +41,41 @@ int main(int argc, char **argv)
 	void *map;
 	uint32_t crc_before, crc_after;
 	struct stat st;
+	char sempath[PATH_MAX];
+	char anchorpath[PATH_MAX];
 
 	test_init(argc, argv);
 
-	/* Clean up any leftovers. */
-	unlink(SEM_NAME);
-	unlink(SEM_ANCHOR);
-
-	/* Step 1: create the file on tmpfs. */
-	fd = open(SEM_NAME, O_RDWR | O_CREAT | O_EXCL, 0600);
-	if (fd < 0) {
-		pr_perror("open");
+	mkdir(dirname, 0700);
+	if (mount("none", dirname, "tmpfs", 0, "") < 0) {
+		pr_perror("mount tmpfs on %s", dirname);
 		return 1;
 	}
-	if (ftruncate(fd, SEM_SIZE) < 0) {
+
+	snprintf(sempath, sizeof(sempath), "%s/sem.zdtm-link-remap-test", dirname);
+	snprintf(anchorpath, sizeof(anchorpath), "%s/sem.zdtm-link-remap-anchor", dirname);
+
+	/* Step 1: create the file on tmpfs. */
+	fd = open(sempath, O_RDWR | O_CREAT | O_EXCL, 0600);
+	if (fd < 0) {
+		pr_perror("open %s", sempath);
+		goto umount;
+	}
+	if (ftruncate(fd, FILE_SIZE) < 0) {
 		pr_perror("ftruncate");
-		return 1;
+		goto umount;
 	}
 
 	/* Step 2: mmap it MAP_SHARED -- creates the file-backed VMA. */
-	map = mmap(NULL, SEM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	map = mmap(NULL, FILE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	if (map == MAP_FAILED) {
 		pr_perror("mmap");
-		return 1;
+		goto umount;
 	}
 
 	/* Write known data and compute CRC before C/R. */
 	crc_before = ~0;
-	datagen(map, SEM_SIZE, &crc_before);
+	datagen(map, FILE_SIZE, &crc_before);
 
 	/*
 	 * Step 3: create a hard link so st_nlink becomes 2.
@@ -74,32 +83,32 @@ int main(int argc, char **argv)
 	 * ensuring CRIU sees st_nlink=1 (not 0) and takes dump_linked_remap
 	 * instead of dump_ghost_remap -- which is the bug trigger.
 	 */
-	if (link(SEM_NAME, SEM_ANCHOR) < 0) {
+	if (link(sempath, anchorpath) < 0) {
 		pr_perror("link");
-		return 1;
+		goto umount;
 	}
 
 	/*
 	 * Step 4: unlink the mapped name.
 	 * st_nlink drops to 1 (anchor survives).
-	 * /proc/PID/maps now shows "sem.zdtm-link-remap-test (deleted)".
+	 * /proc/PID/maps now shows the file as "(deleted)".
 	 * fstatat on that path returns ENOENT.
-	 * CRIU without fix: st_nlink=1 + ENOENT -> dump_linked_remap -> restore fails.
-	 * CRIU with fix:    TMPFS_MAGIC detected -> dump_ghost_remap -> restore works.
+	 * CRIU without fix: st_nlink=1 + ENOENT -> dump_linked_remap -> fails.
+	 * CRIU with fix:    TMPFS_MAGIC detected -> dump_ghost_remap -> works.
 	 */
-	if (unlink(SEM_NAME) < 0) {
+	if (unlink(sempath) < 0) {
 		pr_perror("unlink");
-		return 1;
+		goto umount;
 	}
 
 	/* Verify the trigger state: st_nlink=1, mapped path gone. */
 	if (fstat(fd, &st) < 0) {
 		pr_perror("fstat");
-		return 1;
+		goto umount;
 	}
 	if (st.st_nlink != 1) {
 		fail("Expected st_nlink=1, got %lu", (unsigned long)st.st_nlink);
-		return 1;
+		goto umount;
 	}
 
 	test_daemon();
@@ -107,26 +116,28 @@ int main(int argc, char **argv)
 
 	/* After C/R: verify the mmap content is intact. */
 	crc_after = ~0;
-	if (datachk(map, SEM_SIZE, &crc_after)) {
+	if (datachk(map, FILE_SIZE, &crc_after)) {
 		fail("mmap content CRC mismatch after restore");
-		goto out;
+		goto cleanup;
 	}
 
 	/* Verify the fd is still usable. */
 	if (fstat(fd, &st) < 0) {
 		pr_perror("fstat after restore");
-		goto out;
+		goto cleanup;
 	}
-	if (st.st_size != SEM_SIZE) {
+	if (st.st_size != FILE_SIZE) {
 		fail("fd size changed: expected %d got %lld",
-		     SEM_SIZE, (long long)st.st_size);
-		goto out;
+		     FILE_SIZE, (long long)st.st_size);
+		goto cleanup;
 	}
 
 	pass();
-out:
-	munmap(map, SEM_SIZE);
+cleanup:
+	munmap(map, FILE_SIZE);
 	close(fd);
-	unlink(SEM_ANCHOR); /* clean up anchor */
+	unlink(anchorpath);
+umount:
+	umount2(dirname, MNT_DETACH);
 	return 0;
 }

--- a/test/zdtm/static/tmpfs_link_remap.desc
+++ b/test/zdtm/static/tmpfs_link_remap.desc
@@ -1,0 +1,1 @@
+{'flavor': 'ns uns', 'opts': '--link-remap'}

--- a/test/zdtm/static/tmpfs_link_remap.desc
+++ b/test/zdtm/static/tmpfs_link_remap.desc
@@ -1,1 +1,1 @@
-{'flavor': 'ns uns', 'opts': '--link-remap'}
+{'flavor': 'ns uns', 'flags': 'suid', 'opts': '--link-remap'}


### PR DESCRIPTION
- Reproduced the link remap issue, when we have the case /dev/shm the file is in tmpfs and criu during dump do not use the magic to dump as ghost file

---
### Kimchi Summary
### What changed
Fixes restore failures for mmapped files on external tmpfs mounts (such as `/dev/shm` in containers) that have been unlinked but retain `st_nlink >= 1` by falling back to `dump_ghost_remap()` to embed the file content directly in the checkpoint image. Adds a ZDTM regression test reproducing the POSIX semaphore pattern.

### Why
On external tmpfs mounts CRIU does not dump mount contents, so `link_remap.N` files created by `dump_linked_remap()` are lost during migration; the destination node restores with an empty tmpfs, causing ENOENT and broken VMAs. This change detects external tmpfs mounts and stores the file as a ghost remap instead.

### Key changes
- `criu/files-reg.c`: In `check_path_remap()`, added a `TMPFS_MAGIC` check that falls back to `dump_ghost_remap()` when the mount is external (`mi->external`) or an external bind (`mnt_is_external_bind(mi)`).
- `test/zdtm/static/Makefile`: Added `tmpfs_link_remap` test target.
- `test/zdtm/static/tmpfs_link_remap.c`: Added new regression test that creates a tmpfs file, `mmap`s it, hard-links and unlinks the original name (leaving `st_nlink=1`), then verifies content integrity across checkpoint/restore.
- `test/zdtm/static/tmpfs_link_remap.desc`: Added test descriptor requiring `--link-remap`.

### Impact
- Fixes checkpoint/restore for POSIX semaphores and similar unlinked-tmpfile patterns on container runtime tmpfs mounts.
- No behavior change for CRIU-managed tmpfs mounts (normal tar-based restore path remains unchanged).